### PR TITLE
feat: protected routes

### DIFF
--- a/integration-tests/tests/recommend-books.test.ts
+++ b/integration-tests/tests/recommend-books.test.ts
@@ -1,4 +1,4 @@
-import { POST } from '@/app/api/recommendations/route';
+import { POST } from '@/app/api/protected/recommendations/route';
 import { fakeRecommendation } from '@/lib/fakes/recommendation.fake';
 import bookRecommendationsSchema from '@/lib/schemas/book-recommendations.schema';
 import aiService from '@/lib/services/ai.service';

--- a/src/app/api/protected/recommendations/route.ts
+++ b/src/app/api/protected/recommendations/route.ts
@@ -12,7 +12,7 @@ type ErrorBody = {
 };
 
 export async function POST(): Promise<NextResponse<ResponseBody | ErrorBody>> {
-  logger.trace({}, '/api/recommendations POST');
+  logger.trace({}, '/api/protected/recommendations POST');
 
   try {
     const prompt = new RecommendBooksPrompt();

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -48,7 +48,7 @@ describe('middleware.ts', () => {
     // Add test just to confirm we don't inadvertently change the path
     it('should match all API routes', () => {
       expect(config).toEqual({
-        matcher: '/api/:path*',
+        matcher: '/api/protected/:path*',
       });
     });
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,5 +10,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: '/api/:path*',
+  matcher: '/api/protected/:path*',
 };


### PR DESCRIPTION
## Description

- move the existing routes to /api/protected so that we can distinguish routes which should include auth checks from those that should not.

## Tests

- existing tests cover refactor
