### PR TITLE
feat: login auth API

### DIFF
--- a/integration-tests/create-fixtures.ts
+++ b/integration-tests/create-fixtures.ts
@@ -1,12 +1,14 @@
+import userService from '@/lib/services/user.service';
 import { PrismaClient } from '@prisma/client';
 import bookReviewFixtures from './fixtures/book-review.fixture';
 import userFixtures from './fixtures/user.fixture';
 const prisma = new PrismaClient();
 
 async function createFixtures() {
-  await prisma.user.createMany({
-    data: userFixtures,
-  });
+  // use user service to make sure we add user's correctly
+  for (const user of userFixtures) {
+    await userService.addUser({ user });
+  }
 
   // the first user gets the book reviews
   const user = await prisma.user.findFirstOrThrow();

--- a/integration-tests/tests/auth/post-auth.test.ts
+++ b/integration-tests/tests/auth/post-auth.test.ts
@@ -1,0 +1,114 @@
+import {
+  AuthPostRequestBody,
+  AuthPostResponseBody,
+  POST,
+} from '@/app/api/auth/route';
+import projectConfig from '@/config/index';
+import prisma from '@/lib/prisma';
+import NextResponseErrorBody from '@/types/NextResponseErrorBody';
+import { User } from '@prisma/client';
+import { NextRequest } from 'next/server';
+import userFixtures from '../../fixtures/user.fixture';
+
+const mockSetCookies = jest.fn();
+jest.mock('next/headers', () => ({
+  cookies: () => ({
+    set: (...args: unknown[]) => mockSetCookies(...args),
+  }),
+}));
+
+const url = 'https://localhost';
+
+describe('/auth POST API', () => {
+  const userFixture = userFixtures[0];
+  let user: User;
+
+  beforeEach(async () => {
+    mockSetCookies.mockReset();
+
+    user = await prisma.user.findFirstOrThrow({
+      where: { email: userFixture.email },
+    });
+  });
+
+  it('should return auth cookie on successful login', async () => {
+    const body: AuthPostRequestBody = {
+      email: userFixture.email,
+      password: userFixture.password,
+    };
+    const request = new NextRequest(url, {
+      body: JSON.stringify(body),
+      method: 'POST',
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toEqual(200);
+    const responseBody: AuthPostResponseBody | NextResponseErrorBody =
+      await response.json();
+    expect(responseBody).toEqual({});
+
+    expect(mockSetCookies).toHaveBeenCalledWith(
+      projectConfig.auth.cookieName,
+      user.uuid,
+    );
+  });
+
+  it('should return Unauthorized when user does not exist', async () => {
+    const body: AuthPostRequestBody = {
+      email: 'user@doesnotexist.com',
+      password: 'password',
+    };
+    const request = new NextRequest(url, {
+      body: JSON.stringify(body),
+      method: 'POST',
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toEqual(401);
+
+    expect(mockSetCookies).not.toHaveBeenCalled();
+  });
+
+  it('should return Unauthorized when password does not match', async () => {
+    const body: AuthPostRequestBody = {
+      email: userFixture.email,
+      password: 'bad',
+    };
+    const request = new NextRequest(url, {
+      body: JSON.stringify(body),
+      method: 'POST',
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toEqual(401);
+    const responseBody: AuthPostResponseBody | NextResponseErrorBody =
+      await response.json();
+    expect(responseBody).toEqual({ error: 'Unauthorized' });
+
+    expect(mockSetCookies).not.toHaveBeenCalled();
+  });
+
+  it('should return Unknown error when Error occurs', async () => {
+    mockSetCookies.mockImplementation(() => {
+      throw new Error('bad');
+    });
+    const body: AuthPostRequestBody = {
+      email: userFixture.email,
+      password: userFixture.password,
+    };
+    const request = new NextRequest(url, {
+      body: JSON.stringify(body),
+      method: 'POST',
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toEqual(500);
+    const responseBody: AuthPostResponseBody | NextResponseErrorBody =
+      await response.json();
+    expect(responseBody).toEqual({ error: 'Unknown error' });
+  });
+});

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -1,0 +1,61 @@
+import projectConfig from '@/config/index';
+import { comparePassword } from '@/lib/encryption';
+import logger from '@/lib/logger';
+import { UnauthorizedError } from '@/lib/middleware';
+import prisma from '@/lib/prisma';
+import NextResponseErrorBody from '@/types/NextResponseErrorBody';
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+
+const authCookieName = projectConfig.auth.cookieName;
+
+export type AuthPostRequestBody = {
+  email: string;
+  password: string;
+};
+
+export type AuthPostResponseBody = Record<string, never>;
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<AuthPostResponseBody | NextResponseErrorBody>> {
+  logger.trace({}, `${request.nextUrl.pathname} ${request.method}`);
+
+  try {
+    const { email, password } = (await request.json()) as AuthPostRequestBody;
+    logger.trace({ email }, 'Attempted login');
+
+    const user = await prisma.user.findFirst({ where: { email } });
+    if (!user) {
+      logger.trace({ email }, 'User not found, returning UnauthorizedError');
+      throw new UnauthorizedError();
+    }
+
+    const isValidPassword = await comparePassword({
+      hash: user.password,
+      password,
+    });
+    if (!isValidPassword) {
+      logger.trace({ email }, 'Invalid password, returning UnauthorizedError');
+      throw new UnauthorizedError();
+    }
+
+    logger.trace({ email }, 'Valid login auth');
+    const cookieStore = cookies();
+    cookieStore.set(authCookieName, user.uuid);
+
+    return NextResponse.json({});
+  } catch (error: unknown) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    } else {
+      let errorMessage;
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      logger.error({ errorMessage }, 'Error occurred in login auth');
+
+      return NextResponse.json({ error: 'Unknown error' }, { status: 500 });
+    }
+  }
+}


### PR DESCRIPTION
## Description

- add an API to authenticate the user and return an auth cookie, containing the user's UUID.

## Tests

- add an integration test for login
