### PR TITLE
feat: User omit password

### DIFF
--- a/integration-tests/tests/auth/get-auth.test.ts
+++ b/integration-tests/tests/auth/get-auth.test.ts
@@ -2,7 +2,7 @@ import { AuthGetResponseBody, GET } from '@/app/api/auth/route';
 import projectConfig from '@/config/index';
 import prisma from '@/lib/prisma';
 import NextResponseErrorBody from '@/types/NextResponseErrorBody';
-import { User } from '@prisma/client';
+import User from '@/types/User';
 import { NextRequest } from 'next/server';
 import userFixtures from '../../fixtures/user.fixture';
 
@@ -12,7 +12,7 @@ describe('GET /auth API Integration Test', () => {
   const userFixture = userFixtures[0];
   let user: User;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     user = await prisma.user.findFirstOrThrow({
       where: { email: userFixture.email },
     });

--- a/integration-tests/tests/auth/post-auth.test.ts
+++ b/integration-tests/tests/auth/post-auth.test.ts
@@ -6,7 +6,7 @@ import {
 import projectConfig from '@/config/index';
 import prisma from '@/lib/prisma';
 import NextResponseErrorBody from '@/types/NextResponseErrorBody';
-import { User } from '@prisma/client';
+import User from '@/types/User';
 import { NextRequest } from 'next/server';
 import userFixtures from '../../fixtures/user.fixture';
 
@@ -23,12 +23,14 @@ describe('/auth POST API', () => {
   const userFixture = userFixtures[0];
   let user: User;
 
-  beforeEach(async () => {
-    mockSetCookies.mockReset();
-
+  beforeAll(async () => {
     user = await prisma.user.findFirstOrThrow({
       where: { email: userFixture.email },
     });
+  });
+
+  beforeEach(async () => {
+    mockSetCookies.mockReset();
   });
 
   it('should return auth cookie on successful login', async () => {
@@ -46,7 +48,10 @@ describe('/auth POST API', () => {
     expect(response.status).toEqual(200);
     const responseBody: AuthPostResponseBody | NextResponseErrorBody =
       await response.json();
-    expect(responseBody).toEqual({});
+    expect(responseBody).toEqual({
+      email: userFixture.email,
+      isLoggedIn: true,
+    });
 
     expect(mockSetCookies).toHaveBeenCalledWith(
       projectConfig.auth.cookieName,

--- a/integration-tests/tests/create-user.test.ts
+++ b/integration-tests/tests/create-user.test.ts
@@ -23,17 +23,16 @@ describe('Create User Integration Test', () => {
       },
     });
 
-    const { email, password, uuid } = createdUser;
+    const { email, uuid } = createdUser;
     expect(email).toEqual(USER_EMAIL);
-    expect(
-      await comparePassword({
-        hash: password,
-        password: USER_PASSWORD,
-      }),
-    ).toEqual(true);
     expect(uuid).toBeDefined();
 
     const foundUser = await prisma.user.findFirst({
+      select: {
+        email: true,
+        password: true,
+        uuid: true,
+      },
       where: { email: USER_EMAIL },
     });
     expect(foundUser).toBeDefined();

--- a/integration-tests/tests/recommend-books.test.ts
+++ b/integration-tests/tests/recommend-books.test.ts
@@ -15,7 +15,7 @@ const mockCreateMessage = jest.spyOn(aiService, 'createMessage');
 describe('Recommend Books Integration Test', () => {
   let request: NextRequest;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const user = await prisma.user.findFirstOrThrow();
     request = new NextRequest('http://localhost');
     request.cookies.set(projectConfig.auth.cookieName, user.uuid);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,9 @@
 // https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  // https://www.prisma.io/docs/orm/prisma-client/queries/excluding-fields
+  previewFeatures = ["omitApi"]
 }
 
 datasource db {

--- a/prisma/seeds/users/users.seeds.ts
+++ b/prisma/seeds/users/users.seeds.ts
@@ -1,7 +1,7 @@
 import userService from '@/lib/services/user.service';
-import { User } from '@prisma/client';
+import UserCreateInput from '@/types/UserCreateInput';
 
-export const USERS: Pick<User, 'email' | 'password'>[] = [
+export const USERS: UserCreateInput[] = [
   { email: 'test@fake.com', password: 'password' },
 ];
 

--- a/src/lib/fakes/user.fake.ts
+++ b/src/lib/fakes/user.fake.ts
@@ -1,12 +1,11 @@
+import User from '@/types/User';
 import { faker } from '@faker-js/faker';
-import { User } from '@prisma/client';
 
 export function fakeUser(): User {
   return {
     createdAt: faker.date.past(),
     email: faker.internet.email(),
     id: faker.number.int(),
-    password: faker.string.nanoid(),
     updatedAt: faker.date.past(),
     uuid: faker.string.uuid(),
   };

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -3,7 +3,13 @@
 import { PrismaClient } from '@prisma/client';
 
 const prismaClientSingleton = () => {
-  return new PrismaClient();
+  return new PrismaClient({
+    omit: {
+      user: {
+        password: true,
+      },
+    },
+  });
 };
 
 declare const globalThis: {

--- a/src/lib/services/user.service.ts
+++ b/src/lib/services/user.service.ts
@@ -1,7 +1,7 @@
 import { encryptPassword } from '@/lib/encryption';
 import prisma from '@/lib/prisma';
+import User from '@/types/User';
 import UserCreateInput from '@/types/UserCreateInput';
-import { User } from '@prisma/client';
 
 class UserService {
   private static instance: UserService;

--- a/src/types/AuthResponse.ts
+++ b/src/types/AuthResponse.ts
@@ -1,6 +1,6 @@
-import { User } from '@prisma/client';
+import User from '@/types/User';
 
-type UserAuthGetResponse =
+type AuthResponse =
   | {
       isLoggedIn: true;
       email: User['email'];
@@ -9,4 +9,4 @@ type UserAuthGetResponse =
       isLoggedIn: false;
     };
 
-export default UserAuthGetResponse;
+export default AuthResponse;

--- a/src/types/Session.ts
+++ b/src/types/Session.ts
@@ -1,4 +1,4 @@
-import { User } from '@prisma/client';
+import User from '@/types/User';
 
 type Session = {
   user: User;

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,5 @@
+import { User as PrismaUser } from '@prisma/client';
+
+type User = Omit<PrismaUser, 'password'>;
+
+export default User;

--- a/src/types/UserCreateInput.ts
+++ b/src/types/UserCreateInput.ts
@@ -1,5 +1,5 @@
-import { User } from '@prisma/client';
+import { User as PrismaUser } from '@prisma/client';
 
-type UserCreateInput = Pick<User, 'email' | 'password'>;
+type UserCreateInput = Pick<PrismaUser, 'email' | 'password'>;
 
 export default UserCreateInput;


### PR DESCRIPTION
## Description

- Add the Prisma preview feature "omitApi" which gives us the ability to omit a field from all queries.
- Use this in the default prisma library to omit the password field from the User. This is done so that we don't accidentally leak the password hash. When we query for a User and want the password, we must state this explicitly.
- The only place where we _need_ the password is in the auth route, which confirms the user's password matches the hash we have stored during login.

## Tests

- Make updates to the types and tests based on these changes.
