### PR TITLE
fix: auth response

### DIFF
--- a/integration-tests/tests/auth/get-auth.test.ts
+++ b/integration-tests/tests/auth/get-auth.test.ts
@@ -26,8 +26,10 @@ describe('GET /auth API Integration Test', () => {
     expect(response.status).toEqual(200);
     const responseBody: AuthGetResponseBody = await response.json();
     expect(responseBody).toEqual({
-      email: user.email,
-      isLoggedIn: true,
+      data: {
+        email: user.email,
+        isLoggedIn: true,
+      },
     });
   });
 
@@ -38,7 +40,7 @@ describe('GET /auth API Integration Test', () => {
     expect(response.status).toEqual(200);
     const responseBody: AuthGetResponseBody = await response.json();
     expect(responseBody).toEqual({
-      isLoggedIn: false,
+      data: { isLoggedIn: false },
     });
   });
 
@@ -50,7 +52,7 @@ describe('GET /auth API Integration Test', () => {
     expect(response.status).toEqual(200);
     const responseBody: AuthGetResponseBody = await response.json();
     expect(responseBody).toEqual({
-      isLoggedIn: false,
+      data: { isLoggedIn: false },
     });
   });
 

--- a/integration-tests/tests/auth/post-auth.test.ts
+++ b/integration-tests/tests/auth/post-auth.test.ts
@@ -49,8 +49,10 @@ describe('/auth POST API', () => {
     const responseBody: AuthPostResponseBody | NextResponseErrorBody =
       await response.json();
     expect(responseBody).toEqual({
-      email: userFixture.email,
-      isLoggedIn: true,
+      data: {
+        email: userFixture.email,
+        isLoggedIn: true,
+      },
     });
 
     expect(mockSetCookies).toHaveBeenCalledWith(

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -5,7 +5,7 @@ import { handleErrorResponse } from '@/lib/errors/handleErrorResponse';
 import { UnauthorizedError } from '@/lib/errors/UnauthorizedError';
 import logger from '@/lib/logger';
 import prisma from '@/lib/prisma';
-import AuthResponse from '@/types/AuthResponse';
+import Auth from '@/types/Auth';
 import NextResponseErrorBody from '@/types/NextResponseErrorBody';
 import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
@@ -15,7 +15,9 @@ import { fromZodError } from 'zod-validation-error';
 
 const authCookieName = projectConfig.auth.cookieName;
 
-export type AuthGetResponseBody = AuthResponse;
+export type AuthGetResponseBody = {
+  data: Auth;
+};
 
 export async function GET(
   request: NextRequest,
@@ -28,7 +30,7 @@ export async function GET(
     if (!uuid) {
       logger.trace({}, 'No uuid in auth cookie, returning not logged in');
       return NextResponse.json({
-        isLoggedIn: false,
+        data: { isLoggedIn: false },
       });
     }
 
@@ -36,13 +38,15 @@ export async function GET(
     if (!user) {
       logger.trace({ uuid }, 'No user for uuid, returning not logged in');
       return NextResponse.json({
-        isLoggedIn: false,
+        data: { isLoggedIn: false },
       });
     }
 
     return NextResponse.json({
-      email: user.email,
-      isLoggedIn: true,
+      data: {
+        email: user.email,
+        isLoggedIn: true,
+      },
     });
   } catch (error: unknown) {
     return handleErrorResponse(error);
@@ -59,7 +63,9 @@ const postSchema: toZod<AuthPostRequestBody> = z.object({
   password: z.string(),
 });
 
-export type AuthPostResponseBody = AuthResponse;
+export type AuthPostResponseBody = {
+  data: Auth;
+};
 
 export async function POST(
   request: NextRequest,
@@ -106,8 +112,10 @@ export async function POST(
     cookieStore.set(authCookieName, user.uuid);
 
     return NextResponse.json({
-      email: user.email,
-      isLoggedIn: true,
+      data: {
+        email: user.email,
+        isLoggedIn: true,
+      },
     });
   } catch (error: unknown) {
     return handleErrorResponse(error);

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -1,6 +1,6 @@
 import User from '@/types/User';
 
-type AuthResponse =
+type Auth =
   | {
       isLoggedIn: true;
       email: User['email'];
@@ -9,4 +9,4 @@ type AuthResponse =
       isLoggedIn: false;
     };
 
-export default AuthResponse;
+export default Auth;


### PR DESCRIPTION
## Description

- The auth response should be wrapped with a `data` key
- Rename `AuthResponse` type to `Auth` for easier re-use on the client.

## Tests

- update existing tests
