### PR TITLE
chore: eslint no-console

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,6 +11,7 @@ plugins:
   - prettier
 root: true
 rules:
+  no-console: "warn"
   prettier/prettier: 2
   sort-keys:
     - error

--- a/src/lib/prompts/BasePrompt.ts
+++ b/src/lib/prompts/BasePrompt.ts
@@ -10,7 +10,9 @@ export default abstract class BasePrompt<Result> implements Prompt<Result> {
   abstract execute(): Promise<Result | string>;
 
   async logPrompts(): Promise<void> {
+    // eslint-disable-next-line no-console
     console.log(await this.getSystemPrompt());
+    // eslint-disable-next-line no-console
     console.log(await this.getUserPrompt());
   }
 

--- a/src/scripts/run-prompt.ts
+++ b/src/scripts/run-prompt.ts
@@ -12,6 +12,7 @@ async function runPrompt() {
   const instance = new PromptClass();
 
   const response = await instance.execute();
+  // eslint-disable-next-line no-console
   console.log(response);
 }
 


### PR DESCRIPTION
## Description

- enable no-console eslint as a warning
- disable linting where we intentionally console log

## Tests

- eslint shows warnings now
