### PR TITLE
feat: login errors

### DIFF
--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -1,8 +1,8 @@
 import projectConfig from '@/config/index';
 import { comparePassword } from '@/lib/encryption';
-import { BadRequestError } from '@/lib/errors/BadRequestError';
-import { handleErrorResponse } from '@/lib/errors/handleErrorResponse';
-import { UnauthorizedError } from '@/lib/errors/UnauthorizedError';
+import BadRequestError from '@/lib/errors/BadRequestError';
+import handleErrorResponse from '@/lib/errors/handleErrorResponse';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 import logger from '@/lib/logger';
 import prisma from '@/lib/prisma';
 import Auth from '@/types/Auth';

--- a/src/app/api/protected/recommendations/route.ts
+++ b/src/app/api/protected/recommendations/route.ts
@@ -1,4 +1,4 @@
-import { handleErrorResponse } from '@/lib/errors/handleErrorResponse';
+import handleErrorResponse from '@/lib/errors/handleErrorResponse';
 import logger from '@/lib/logger';
 import { authMiddleware } from '@/lib/middleware';
 import RecommendBooksPrompt from '@/lib/prompts/RecommendBooksPrompt';

--- a/src/hooks/useHandleError.test.ts
+++ b/src/hooks/useHandleError.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import useHandleError from '@/hooks/useHandleError';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
+import { renderHook } from '@testing-library/react';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+describe('useHandleError', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('route to the login page on UnauthorizedError', () => {
+    const {
+      result: {
+        current: { handleError },
+      },
+    } = renderHook(() => useHandleError());
+
+    handleError(new UnauthorizedError());
+
+    expect(mockPush).toHaveBeenCalledWith('/login?login-error=unauthorized');
+  });
+
+  it('route to error page on Error', () => {
+    const {
+      result: {
+        current: { handleError },
+      },
+    } = renderHook(() => useHandleError());
+
+    handleError(new Error());
+
+    expect(mockPush).toHaveBeenCalledWith('/500');
+  });
+});

--- a/src/hooks/useHandleError.ts
+++ b/src/hooks/useHandleError.ts
@@ -1,0 +1,28 @@
+import useLoginError from '@/hooks/useLoginError';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
+import LoginError from '@/types/LoginError';
+import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
+
+export type UseHandleErrorResult = {
+  handleError: (error: unknown) => void;
+};
+
+export default function useHandleError(): UseHandleErrorResult {
+  const router = useRouter();
+  const { buildLoginErrorUrl } = useLoginError();
+
+  const handleError = useCallback(
+    (error: unknown) => {
+      if (error instanceof UnauthorizedError) {
+        return router.push(buildLoginErrorUrl(LoginError.UNAUTHORIZED));
+      } else {
+        // TODO what to do here?
+        return router.push('/500');
+      }
+    },
+    [buildLoginErrorUrl, router],
+  );
+
+  return { handleError };
+}

--- a/src/hooks/useLoginError.test.ts
+++ b/src/hooks/useLoginError.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import useLoginError, { UseLoginErrorResult } from '@/hooks/useLoginError';
+import LoginError from '@/types/LoginError';
+import { renderHook } from '@testing-library/react';
+
+describe('useLoginError', () => {
+  describe('buildLoginErrorUrl', () => {
+    let buildLoginErrorUrl: UseLoginErrorResult['buildLoginErrorUrl'];
+
+    beforeEach(() => {
+      ({
+        result: {
+          current: { buildLoginErrorUrl },
+        },
+      } = renderHook(() => useLoginError()));
+    });
+
+    it('should build the correct invalid login url', () => {
+      expect(buildLoginErrorUrl(LoginError.INVALID_LOGIN)).toEqual(
+        '/login?login-error=invalid-login',
+      );
+    });
+
+    it('should build the correct unauthorized url', () => {
+      expect(buildLoginErrorUrl(LoginError.UNAUTHORIZED)).toEqual(
+        '/login?login-error=unauthorized',
+      );
+    });
+  });
+
+  describe('parseLoginErrorUrl', () => {
+    let parseLoginErrorUrl: UseLoginErrorResult['parseLoginErrorUrl'];
+
+    beforeEach(() => {
+      ({
+        result: {
+          current: { parseLoginErrorUrl },
+        },
+      } = renderHook(() => useLoginError()));
+    });
+
+    it('should parse invalid login', () => {
+      const searchParams = new URLSearchParams('login-error=invalid-login');
+      expect(parseLoginErrorUrl(searchParams)).toEqual({
+        errorMessage: 'Invalid email and/or password',
+      });
+    });
+
+    it('should parse unauthorized', () => {
+      const searchParams = new URLSearchParams('login-error=unauthorized');
+      expect(parseLoginErrorUrl(searchParams)).toEqual({
+        errorMessage: 'Please login to continue',
+      });
+    });
+  });
+});

--- a/src/hooks/useLoginError.ts
+++ b/src/hooks/useLoginError.ts
@@ -1,0 +1,36 @@
+import LoginError from '@/types/LoginError';
+import { useCallback } from 'react';
+
+export type UseLoginErrorResult = {
+  buildLoginErrorUrl: (loginError: LoginError) => string;
+  parseLoginErrorUrl: (searchParams: URLSearchParams) => {
+    errorMessage?: string;
+  };
+};
+
+const KEY = 'login-error';
+const VALUES = {
+  [LoginError.INVALID_LOGIN]: 'invalid-login',
+  [LoginError.UNAUTHORIZED]: 'unauthorized',
+} as const;
+
+export default function useLoginError(): UseLoginErrorResult {
+  const buildLoginErrorUrl = useCallback((loginError: LoginError) => {
+    return `/login?${KEY}=${VALUES[loginError]}`;
+  }, []);
+
+  const parseLoginErrorUrl = useCallback((searchParams: URLSearchParams) => {
+    const loginError = searchParams.get(KEY);
+
+    let errorMessage;
+    if (loginError === VALUES[LoginError.INVALID_LOGIN]) {
+      errorMessage = 'Invalid email and/or password';
+    } else if (loginError === VALUES[LoginError.UNAUTHORIZED]) {
+      errorMessage = 'Please login to continue';
+    }
+
+    return { errorMessage };
+  }, []);
+
+  return { buildLoginErrorUrl, parseLoginErrorUrl };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { AuthPostRequestBody } from '@/app/api/auth/route';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 import Auth from '@/types/Auth';
 
 /**
@@ -11,6 +12,10 @@ import Auth from '@/types/Auth';
  */
 async function api<T>(path: string, fetchOptions?: RequestInit): Promise<T> {
   const response = await fetch(path, fetchOptions);
+
+  if (response.status === 401) {
+    throw new UnauthorizedError();
+  }
 
   if (!response.ok) {
     throw new Error(response.statusText);
@@ -27,7 +32,6 @@ export async function postAuth({
   email,
   password,
 }: AuthPostRequestBody): Promise<Auth> {
-  // TODO handle failed login
   return api<Auth>('/api/auth', {
     body: JSON.stringify({ email, password }),
     headers: {

--- a/src/lib/errors/BadRequestError.ts
+++ b/src/lib/errors/BadRequestError.ts
@@ -1,1 +1,1 @@
-export class BadRequestError extends Error {}
+export default class BadRequestError extends Error {}

--- a/src/lib/errors/UnauthorizedError.ts
+++ b/src/lib/errors/UnauthorizedError.ts
@@ -1,1 +1,1 @@
-export class UnauthorizedError extends Error {}
+export default class UnauthorizedError extends Error {}

--- a/src/lib/errors/handleErrorResponse.test.ts
+++ b/src/lib/errors/handleErrorResponse.test.ts
@@ -1,6 +1,6 @@
-import { BadRequestError } from '@/lib/errors/BadRequestError';
-import { handleErrorResponse } from '@/lib/errors/handleErrorResponse';
-import { UnauthorizedError } from '@/lib/errors/UnauthorizedError';
+import BadRequestError from '@/lib/errors/BadRequestError';
+import handleErrorResponse from '@/lib/errors/handleErrorResponse';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 
 describe('handleErrorResponse', () => {
   it('should return 400 for bad request', async () => {

--- a/src/lib/errors/handleErrorResponse.ts
+++ b/src/lib/errors/handleErrorResponse.ts
@@ -1,10 +1,10 @@
-import { BadRequestError } from '@/lib/errors/BadRequestError';
-import { UnauthorizedError } from '@/lib/errors/UnauthorizedError';
+import BadRequestError from '@/lib/errors/BadRequestError';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 import logger from '@/lib/logger';
 import NextResponseErrorBody from '@/types/NextResponseErrorBody';
 import { NextResponse } from 'next/server';
 
-export function handleErrorResponse(
+export default function handleErrorResponse(
   error: unknown,
 ): NextResponse<NextResponseErrorBody> {
   if (error instanceof BadRequestError) {

--- a/src/lib/middleware.test.ts
+++ b/src/lib/middleware.test.ts
@@ -1,5 +1,5 @@
 import projectConfig from '@/config/index';
-import { UnauthorizedError } from '@/lib/errors/UnauthorizedError';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 import { fakeUser } from '@/lib/fakes/user.fake';
 import { authMiddleware } from '@/lib/middleware';
 import prisma from '@/lib/prisma';

--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -1,5 +1,5 @@
 import projectConfig from '@/config/index';
-import { UnauthorizedError } from '@/lib/errors/UnauthorizedError';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 import logger from '@/lib/logger';
 import prisma from '@/lib/prisma';
 import Session from '@/types/Session';

--- a/src/types/LoginError.ts
+++ b/src/types/LoginError.ts
@@ -1,0 +1,6 @@
+enum LoginError {
+  INVALID_LOGIN,
+  UNAUTHORIZED,
+}
+
+export default LoginError;


### PR DESCRIPTION
## Description

When we make API calls via a user action (event), we must handle errors thrown directly with try/catch. Error boundaries can help with rendering issues.

- Update the api code for the unauthorized case to redirect to the login page. This is done via hooks (`useHandleError`) which will wrap API calls in the event code. The first of which is in the login page itself, which can get an error if the credentials are invalid.
- Add another hook to centralize the transmission of these unauthorized errors (`useLoginError`). This allows us to build and parse the URL when we need to redirect to the login page and display an error message.
- While we're here, update the error code to export default where we only have a single export.

## Tests

- add tests for new hooks

### Demos

login success

https://github.com/user-attachments/assets/97fde2cb-388b-4579-9189-0e1b874f476e

login failure


https://github.com/user-attachments/assets/ba46284b-8d6c-434f-920f-b8e323c9825c

login redirect (image)

![login-redirect](https://github.com/user-attachments/assets/e3ac6e45-cbfc-4694-b920-5775f0649d77)

