### PR TITLE
feat: skip google book search on fake rec's

### DIFF
--- a/src/app/api/protected/book-recommendations/route.ts
+++ b/src/app/api/protected/book-recommendations/route.ts
@@ -1,4 +1,4 @@
-import projectConfig from '@/config/index';
+import { default as config, default as projectConfig } from '@/config/index';
 import handleErrorResponse from '@/lib/errors/handleErrorResponse';
 import logger from '@/lib/logger';
 import { authMiddleware } from '@/lib/middleware';
@@ -10,6 +10,8 @@ import HydratedBookRecommendation from '@/types/HydratedBookRecommendation';
 import NextResponseErrorBody from '@/types/NextResponseErrorBody';
 import Session from '@/types/Session';
 import { NextRequest, NextResponse } from 'next/server';
+
+const isFakeRecommendations = config.prompts.useFakeResponses === 'true';
 
 export type PostResponseBody = {
   data: HydratedBookRecommendation[];
@@ -38,7 +40,11 @@ export async function POST(
       async (recommendation) => {
         const { author, confidenceScore, explanation, title } = recommendation;
 
-        const searchResult = await googleBookSearch({ author, title });
+        // skip the google book search if we've got fake recommendations
+        const searchResult = isFakeRecommendations
+          ? /* istanbul ignore next */
+            null
+          : await googleBookSearch({ author, title });
 
         const book = buildBookFromSearchResult({
           recommendation,


### PR DESCRIPTION
## Description

- when we're in the fake prompt mode (used for development/testing), skip making the google book search call since we'll never match to a real book with fake recommendations.

## Tests

- manually verified it was skipped in the logs
