### PR TITLE
test: split unit and integration tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,6 @@
+# disable nextjs telemetry https://nextjs.org/telemetry
+NEXT_TELEMETRY_DISABLED=1
+
 # Invalidate OpenAI to assure we do not use during tests
 OPENAI_API_KEY='invalid'
 

--- a/.github/workflows/ci.js.yml
+++ b/.github/workflows/ci.js.yml
@@ -8,7 +8,8 @@ on:
     branches: [main]
 
 jobs:
-  ci:
+  lint-and-unit-tests:
+    name: Lint and Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -16,16 +17,27 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
       - name: Run lint
-        run: bun run lint
+        run: npm run lint
+      - name: Run unit tests
+        run: npm test
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
       - name: Run docker-compose
         uses: hoverkraft-tech/compose-action@v2.0.1
         with:
           compose-file: './integration-tests/docker-compose.yml'
       - name: Migrate and seed the test database
         run: npm run ci:db:reset
-      - name: Run tests
-        run: npm run test
+      - name: Run integration tests
+        run: npm run ci:test
   build:
+    name: Next.js Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -33,4 +45,4 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
       - name: Run build
-        run: bun run build
+        run: NODE_ENV=test npm run build

--- a/README.md
+++ b/README.md
@@ -112,11 +112,27 @@ To run both lint and compile TypeScript files:
 npm run lint
 ```
 
-### Unit and Integration Tests
+### Unit Tests
 
-Jest unit tests exist along side the source file. Integration tests exist in [`integration-tests`](integration-tests).
+Jest unit tests exist along side the source files.
 
-The integration tests (which are included in the test run) require a test database. This is setup via Docker Compose, and requires a running Docker instance.
+To run the tests:
+
+```
+npm test
+```
+
+To run tests in watch mode:
+
+```
+npm run test:watch
+```
+
+### Integration Tests
+
+Integration tests exist in [`integration-tests`](integration-tests).
+
+The integration tests require a test database. This is setup via Docker Compose, and requires a running Docker instance.
 
 To run the tests:
 
@@ -137,19 +153,27 @@ npm run ci:db:reset
 - Run the tests
 
 ```
-npm test
+npm run ci:test
 ```
 
 To run tests in watch mode:
 
 ```
-npm run test:watch
+npm run ci:test:watch
 ```
 
 When tests are complete, you can shutdown the test database:
 
 ```
 npm run ci:down
+```
+
+### Code Coverage
+
+To run all the tests and include code coverage, follow the steps above for the specific test types. Then to run the tests:
+
+```
+npm run test:coverage
 ```
 
 ## Storybook

--- a/jest.all.config.ts
+++ b/jest.all.config.ts
@@ -1,0 +1,30 @@
+import type { Config } from 'jest';
+import { config, createJestConfig } from './jest.config';
+
+const extendedConfig: Config = {
+  ...config,
+  collectCoverageFrom: [
+    'src/**/*.ts*',
+    // exclude everything but api from /app
+    '!src/app/**',
+    'src/app/api/**',
+    // exclude all these directories and everything below them
+    '!src/config/**',
+    '!src/lib/fakes/**',
+    '!src/lib/schemas/**',
+    '!src/lib/scratch-data/**',
+    '!src/scripts/**',
+    '!src/types/**',
+  ],
+  coveragePathIgnorePatterns: [
+    'src/components/*',
+    'src/lib/api.ts',
+    'src/lib/logger.ts',
+    'src/lib/openai.ts',
+    'src/lib/prisma.ts',
+    'src/lib/tailwind-utils.ts',
+  ],
+  testPathIgnorePatterns: ['/node_modules/'],
+};
+
+export default createJestConfig(extendedConfig);

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,34 +1,11 @@
 import type { Config } from 'jest';
 import nextJest from 'next/jest.js';
 
-const createJestConfig = nextJest({
-  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+export const createJestConfig = nextJest({
   dir: './',
 });
 
-// Add any custom config to be passed to Jest
-const config: Config = {
-  collectCoverageFrom: [
-    'src/**/*.ts*',
-    // exclude everything but api from /app
-    '!src/app/**',
-    'src/app/api/**',
-    // exclude all these directories and everything below them
-    '!src/config/**',
-    '!src/lib/fakes/**',
-    '!src/lib/schemas/**',
-    '!src/lib/scratch-data/**',
-    '!src/scripts/**',
-    '!src/types/**',
-  ],
-  coveragePathIgnorePatterns: [
-    'src/components/*',
-    'src/lib/api.ts',
-    'src/lib/logger.ts',
-    'src/lib/openai.ts',
-    'src/lib/prisma.ts',
-    'src/lib/tailwind-utils.ts',
-  ],
+export const config: Config = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
@@ -36,7 +13,7 @@ const config: Config = {
     '<rootDir>/test-setup/fetch-polyfill.setup.ts',
     '<rootDir>/test-setup/openai-mock.setup.ts',
   ],
+  testPathIgnorePatterns: ['/node_modules/', '/integration-tests/'],
 };
 
-// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
 export default createJestConfig(config);

--- a/jest.integration-tests.config.ts
+++ b/jest.integration-tests.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'jest';
+import { config, createJestConfig } from './jest.config';
+
+const extendedConfig: Config = {
+  ...config,
+  testPathIgnorePatterns: ['/node_modules/', '/src/'],
+};
+
+export default createJestConfig(extendedConfig);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "20.x"
   },
   "scripts": {
-    "build": "dotenv -e .env.test -- next build",
+    "build": "next build",
     "build-storybook": "storybook build",
     "check-types": "tsc --noemit",
     "ci:db:fixtures": "dotenv -e .env.test -- ts-node -r tsconfig-paths/register --compiler-options '{\"module\":\"CommonJS\"}' integration-tests/create-fixtures.ts",
@@ -14,18 +14,21 @@
     "ci:db:reset": "npm run ci:db:migrate-reset && npm run ci:db:fixtures",
     "ci:down": "docker compose -f ./integration-tests/docker-compose.yml down",
     "ci:up": "docker compose -f ./integration-tests/docker-compose.yml up -d",
+    "ci:test": "dotenv -e .env.test -- jest --config ./jest.integration-tests.config.ts --runInBand",
+    "ci:test:watch": "npm run ci:test -- --watch",
     "db:migrate": "prisma migrate dev",
     "db:reset": "prisma migrate reset",
     "db:seed": "prisma db seed",
     "dev": "next dev",
     "eslint": "next lint",
-    "lint": "bun run eslint && bun run check-types",
+    "lint": "npm run eslint && npm run check-types",
     "log-prompts": "ts-node -r tsconfig-paths/register --compiler-options '{\"module\":\"CommonJS\"}' ./src/scripts/log-prompts.ts",
     "run-prompt": "ts-node -r tsconfig-paths/register --compiler-options '{\"module\":\"CommonJS\"}' ./src/scripts/run-prompt.ts",
     "start": "next start",
-    "test": "dotenv -e .env.test -- jest --coverage --runInBand",
-    "test:watch": "dotenv -e .env.test -- jest --watch",
-    "storybook": "storybook dev -p 6006"
+    "storybook": "storybook dev -p 6006",
+    "test": "dotenv -e .env.test -- jest",
+    "test:coverage": "dotenv -e .env.test -- jest --config ./jest.all.config.ts --coverage --runInBand",
+    "test:watch": "npm run test -- --watch"
   },
   "prisma": {
     "seed": "ts-node -r tsconfig-paths/register --compiler-options {\"module\":\"CommonJS\"} prisma/seeds/run-seeds.ts"


### PR DESCRIPTION
## Description

- keep the unit tests within `npm run test` and `npm run test:watch`
- move the integration tests to `npm run ci:test` and `npm run ci:test:watch`
- add all tests with code coverage to `npm run test:coverage`
- split up the github workflows to mirror our test split
- for the build script, no longer hard code the `.env.test` environment variables, only do that in the github action
