### PR TITLE
feat: add BookPrompt model to the database

### DIFF
--- a/prisma/migrations/20241021222605_add_book_prompt/migration.sql
+++ b/prisma/migrations/20241021222605_add_book_prompt/migration.sql
@@ -1,0 +1,46 @@
+-- DropForeignKey
+ALTER TABLE "BookRecommendation" DROP CONSTRAINT "BookRecommendation_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "BookRecommendation" DROP COLUMN "aiModel",
+DROP COLUMN "userId",
+ADD COLUMN     "bookPromptId" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "BookPrompt" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL,
+    "promptText" TEXT NOT NULL,
+    "promptGenreId" INTEGER,
+    "promptSubgenreId" INTEGER,
+    "aiModel" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "BookPrompt_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Genre" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3),
+    "displayName" TEXT NOT NULL,
+
+    CONSTRAINT "Genre_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Genre_displayName_key" ON "Genre"("displayName");
+
+-- AddForeignKey
+ALTER TABLE "BookPrompt" ADD CONSTRAINT "BookPrompt_promptGenreId_fkey" FOREIGN KEY ("promptGenreId") REFERENCES "Genre"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookPrompt" ADD CONSTRAINT "BookPrompt_promptSubgenreId_fkey" FOREIGN KEY ("promptSubgenreId") REFERENCES "Genre"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookPrompt" ADD CONSTRAINT "BookPrompt_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookRecommendation" ADD CONSTRAINT "BookRecommendation_bookPromptId_fkey" FOREIGN KEY ("bookPromptId") REFERENCES "BookPrompt"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,8 +20,8 @@ model User {
   password String
   uuid     String @default(cuid())
 
-  bookReviews         BookReview[]
-  bookRecommendations BookRecommendation[]
+  bookReviews BookReview[]
+  bookPrompts BookPrompt[]
 }
 
 model Book {
@@ -56,21 +56,51 @@ model BookReview {
   bookId Int
 }
 
+model BookPrompt {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now()) @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @db.Timestamptz(3)
+
+  /// The user defined unique prompt text about the book recommendations
+  promptText       String
+  promptGenreId    Int?
+  promptGenre      Genre? @relation("genreBookPrompts", fields: [promptGenreId], references: [id])
+  promptSubgenreId Int?
+  promptSubgenre   Genre? @relation("subgenreBookPrompts", fields: [promptSubgenreId], references: [id])
+
+  /// For record keeping, the AI model which generated this recommendation
+  aiModel String
+
+  bookRecommendations BookRecommendation[]
+
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId Int
+}
+
 model BookRecommendation {
   id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now()) @db.Timestamptz(3)
   updatedAt DateTime @updatedAt @db.Timestamptz(3)
 
-  /// For record keeping, the AI model which generated this recommendation
-  aiModel         String
   /// how confident the AI was in generating this recommendation (0 to 1)
   confidenceScore Decimal @db.Decimal(3, 2) // includes constraint bounding from 0-1, inclusive
   /// explanation from the AI as to why this was recommended
   explanation     String
 
-  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId Int
+  bookPrompt   BookPrompt @relation(fields: [bookPromptId], references: [id], onDelete: Cascade)
+  bookPromptId Int
 
   book   Book @relation(fields: [bookId], references: [id], onDelete: Cascade)
   bookId Int
+}
+
+model Genre {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now()) @db.Timestamptz(3)
+  updatedAt DateTime? @updatedAt @db.Timestamptz(3)
+
+  displayName String @unique
+
+  genreBookPrompts    BookPrompt[] @relation("genreBookPrompts")
+  subgenreBookPrompts BookPrompt[] @relation("subgenreBookPrompts")
 }

--- a/src/app/(protected)/recommendations/page.tsx
+++ b/src/app/(protected)/recommendations/page.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import useBookReviews from '@/hooks/useBookReviews';
 import useHandleError from '@/hooks/useHandleError';
-import { postBookRecommendations } from '@/lib/api';
+import { postBookPrompt } from '@/lib/api';
 import HydratedBookRecommendation from '@/types/HydratedBookRecommendation';
 import { BookCopyIcon } from 'lucide-react';
 import { useCallback, useState } from 'react';
@@ -19,9 +19,11 @@ export default function RecommendationsPage() {
   const { bookReviews, createBookReview, updateBookReview } = useBookReviews();
 
   const generateRecommendations = useCallback(async () => {
+    // TODO gather this from form input
+    const promptText = 'feature witches (but not necessarily in the title)';
     try {
-      const generatedRecommendations = await postBookRecommendations();
-      setRecommendations(generatedRecommendations);
+      const bookPrompt = await postBookPrompt({ promptText });
+      setRecommendations(bookPrompt.bookRecommendations);
     } catch (error) {
       return handleError(error);
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,10 @@
 import { AuthPostRequestBody } from '@/app/api/auth/route';
+import { PostRequestBody as BookPromptPostRequestBody } from '@/app/api/protected/book-prompts/route';
 import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 import Auth from '@/types/Auth';
 import BookReviewCreateInput from '@/types/BookReviewCreateInput';
 import BookReviewUpdateInput from '@/types/BookReviewUpdateInput';
-import HydratedBookRecommendation from '@/types/HydratedBookRecommendation';
+import HydratedBookPrompt from '@/types/HydratedBookPrompt';
 import { BookReview } from '@prisma/client';
 
 /**
@@ -51,15 +52,16 @@ export async function deleteAuth(): Promise<Auth> {
   });
 }
 
-export async function postBookRecommendations(): Promise<
-  HydratedBookRecommendation[]
-> {
-  return api<HydratedBookRecommendation[]>(
-    '/api/protected/book-recommendations',
-    {
-      method: 'POST',
+export async function postBookPrompt(
+  body: BookPromptPostRequestBody,
+): Promise<HydratedBookPrompt> {
+  return api<HydratedBookPrompt>('/api/protected/book-prompts', {
+    body: JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json',
     },
-  );
+    method: 'POST',
+  });
 }
 
 export async function getBookReviews(): Promise<BookReview[]> {

--- a/src/lib/fakes/bookPrompt.fake.ts
+++ b/src/lib/fakes/bookPrompt.fake.ts
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker';
+import { BookPrompt } from '@prisma/client';
+
+export function fakeBookPrompt(): BookPrompt {
+  return {
+    aiModel: faker.lorem.word(),
+    createdAt: faker.date.past(),
+    id: faker.number.int(),
+    promptGenreId: faker.number.int(),
+    promptSubgenreId: faker.number.int(),
+    promptText: faker.lorem.sentence(),
+    updatedAt: faker.date.past(),
+    userId: faker.number.int(),
+  };
+}

--- a/src/lib/fakes/recommendation.fake.ts
+++ b/src/lib/fakes/recommendation.fake.ts
@@ -15,14 +15,13 @@ export function fakeAIBookRecommendation(): AIBookRecommendation {
 
 export function fakeBookRecommendation(): BookRecommendation {
   return {
-    aiModel: faker.lorem.word(),
     bookId: faker.number.int(),
+    bookPromptId: faker.number.int(),
     confidenceScore: new Prisma.Decimal(faker.number.float()),
     createdAt: faker.date.past(),
     explanation: faker.lorem.paragraph(),
     id: faker.number.int(),
     updatedAt: faker.date.past(),
-    userId: faker.number.int(),
   };
 }
 

--- a/src/lib/prompts/RecommendBooksPrompt.test.ts
+++ b/src/lib/prompts/RecommendBooksPrompt.test.ts
@@ -19,7 +19,7 @@ describe('RecommendBooksPrompt', () => {
   });
 
   beforeEach(() => {
-    prompt = new RecommendBooksPrompt({ user: {} as User });
+    prompt = new RecommendBooksPrompt({ promptText: '', user: {} as User });
   });
 
   describe('when shouldUseFakeResponses is enabled', () => {

--- a/src/lib/prompts/RecommendBooksPrompt.ts
+++ b/src/lib/prompts/RecommendBooksPrompt.ts
@@ -10,6 +10,7 @@ import User from '@/types/User';
 import _ from 'lodash';
 
 export type RecommendBooksPromptProps = {
+  promptText: string;
   user: User;
 };
 
@@ -17,11 +18,13 @@ export default class RecommendBooksPrompt
   extends BasePrompt<AIBookRecommendation[]>
   implements Prompt<AIBookRecommendation[]>
 {
+  private promptText: string;
   private user: User;
 
-  constructor({ user }: RecommendBooksPromptProps) {
+  constructor({ promptText, user }: RecommendBooksPromptProps) {
     super();
 
+    this.promptText = promptText;
     this.user = user;
   }
 
@@ -59,7 +62,7 @@ titles, just to find that perfect book recommendation.
     return Promise.resolve(`
 OBJECTIVE:
 - Recommend and return only 5 books
-- The books should all feature witches (but not necessarily in the title).
+- The books should all ${this.promptText}.
 - The books should be all in the Romantic genre.
 - The books should be all in the Comedy subgenre.
 

--- a/src/types/HydratedBookPrompt.ts
+++ b/src/types/HydratedBookPrompt.ts
@@ -1,0 +1,8 @@
+import HydratedBookRecommendation from '@/types/HydratedBookRecommendation';
+import { BookPrompt } from '@prisma/client';
+
+type HydratedBookPrompt = Omit<BookPrompt, 'userId' | 'aiModel'> & {
+  bookRecommendations: HydratedBookRecommendation[];
+};
+
+export default HydratedBookPrompt;

--- a/src/types/HydratedBookRecommendation.ts
+++ b/src/types/HydratedBookRecommendation.ts
@@ -2,7 +2,7 @@ import { Book, BookRecommendation } from '@prisma/client';
 
 type HydratedBookRecommendation = Omit<
   BookRecommendation,
-  'userId' | 'bookId' | 'aiModel'
+  'bookPromptId' | 'bookId'
 > & {
   book: Book;
 };


### PR DESCRIPTION
## Description

- refactor the database schema to include a parent `BookPrompt` which hosts `BookRecommendation`s, along with the prompt details to generate the recommendations.
- build out a new API to create `BookPrompt`s, replacing the old book-recommendations API.

## Tests

- add integration test for new API
- update existing tests
