### PR TITLE
chore: refactor book-prompt route + test auth

### DIFF
--- a/integration-tests/test-lib/auth.ts
+++ b/integration-tests/test-lib/auth.ts
@@ -1,0 +1,13 @@
+import config from '@/config/index';
+import User from '@/types/User';
+import { NextRequest } from 'next/server';
+
+export function establishAuth({
+  request,
+  user,
+}: {
+  request: NextRequest;
+  user: User;
+}): void {
+  request.cookies.set(config.auth.cookieName, user.uuid);
+}

--- a/integration-tests/tests/book-reviews/get-book-reviews.test.ts
+++ b/integration-tests/tests/book-reviews/get-book-reviews.test.ts
@@ -1,18 +1,19 @@
 import { GET, GetResponseBody } from '@/app/api/protected/book-reviews/route';
-import projectConfig from '@/config/index';
 import prisma from '@/lib/prisma';
+import User from '@/types/User';
 import { BookReview } from '@prisma/client';
 import { NextRequest } from 'next/server';
 import { USER_WITH_REVIEWS_EMAIL } from '../../fixtures/user.fixture';
+import { establishAuth } from '../../test-lib/auth';
 
 const url = 'https://localhost';
 
 describe('/book-reviews GET', () => {
-  let uuid: string;
+  let user: User & { bookReviews: BookReview[] };
   let existingBookReviews: BookReview[];
 
   beforeAll(async () => {
-    const user = await prisma.user.findFirstOrThrow({
+    user = await prisma.user.findFirstOrThrow({
       include: {
         bookReviews: true,
       },
@@ -20,14 +21,13 @@ describe('/book-reviews GET', () => {
     });
 
     existingBookReviews = user.bookReviews;
-    uuid = user.uuid;
   });
 
   it('should return the book reviews', async () => {
     const request = new NextRequest(url, {
       method: 'GET',
     });
-    request.cookies.set(projectConfig.auth.cookieName, uuid);
+    establishAuth({ request, user });
 
     const response = await GET(request);
 

--- a/integration-tests/tests/book-reviews/post-book-reviews.test.ts
+++ b/integration-tests/tests/book-reviews/post-book-reviews.test.ts
@@ -1,25 +1,23 @@
 import { POST, PostResponseBody } from '@/app/api/protected/book-reviews/route';
-import projectConfig from '@/config/index';
 import { isbnHash } from '@/lib/hash';
 import prisma from '@/lib/prisma';
 import BookReviewCreateInput from '@/types/BookReviewCreateInput';
+import User from '@/types/User';
 import { Book } from '@prisma/client';
 import { NextRequest } from 'next/server';
 import { USER_NO_REVIEWS_EMAIL } from '../../fixtures/user.fixture';
+import { establishAuth } from '../../test-lib/auth';
 
 const url = 'https://localhost';
 
 describe('/api/protected/book-reviews POST', () => {
-  let uuid: string;
+  let user: User;
   let book: Book;
 
   beforeAll(async () => {
-    const user = await prisma.user.findFirstOrThrow({
-      select: { uuid: true },
+    user = await prisma.user.findFirstOrThrow({
       where: { email: USER_NO_REVIEWS_EMAIL },
     });
-
-    uuid = user.uuid;
 
     const authors = ['POST book-reviews test author'];
     const title = 'My Title';
@@ -50,7 +48,7 @@ describe('/api/protected/book-reviews POST', () => {
       body: JSON.stringify(bookReview),
       method: 'POST',
     });
-    request.cookies.set(projectConfig.auth.cookieName, uuid);
+    establishAuth({ request, user });
 
     const response = await POST(request);
 
@@ -75,7 +73,7 @@ describe('/api/protected/book-reviews POST', () => {
       body: JSON.stringify(bookReview),
       method: 'POST',
     });
-    request.cookies.set(projectConfig.auth.cookieName, uuid);
+    establishAuth({ request, user });
 
     const response = await POST(request);
 
@@ -96,7 +94,7 @@ describe('/api/protected/book-reviews POST', () => {
       body: JSON.stringify(bookReview),
       method: 'POST',
     });
-    request.cookies.set(projectConfig.auth.cookieName, uuid);
+    establishAuth({ request, user });
 
     const response = await POST(request);
 
@@ -123,7 +121,7 @@ describe('/api/protected/book-reviews POST', () => {
       body: JSON.stringify({ bad: 'data' }),
       method: 'POST',
     });
-    request.cookies.set(projectConfig.auth.cookieName, uuid);
+    establishAuth({ request, user });
 
     const response = await POST(request);
 

--- a/integration-tests/tests/book-reviews/put-book-review.test.ts
+++ b/integration-tests/tests/book-reviews/put-book-review.test.ts
@@ -2,24 +2,25 @@ import {
   PUT,
   PutResponseBody,
 } from '@/app/api/protected/book-reviews/[bookReviewId]/route';
-import projectConfig from '@/config/index';
 import prisma from '@/lib/prisma';
 import BookReviewUpdateInput from '@/types/BookReviewUpdateInput';
+import User from '@/types/User';
 import { BookReview } from '@prisma/client';
 import { NextRequest } from 'next/server';
 import {
   USER_WITH_ONE_REVIEW_EMAIL,
   USER_WITH_REVIEWS_EMAIL,
 } from '../../fixtures/user.fixture';
+import { establishAuth } from '../../test-lib/auth';
 
 const url = 'https://localhost';
 
 describe('/book-reviews/[bookReviewId] PUT', () => {
-  let uuid: string;
+  let user: User & { bookReviews: BookReview[] };
   let existingBookReview: BookReview;
 
   beforeAll(async () => {
-    const user = await prisma.user.findFirstOrThrow({
+    user = await prisma.user.findFirstOrThrow({
       include: {
         bookReviews: true,
       },
@@ -27,7 +28,6 @@ describe('/book-reviews/[bookReviewId] PUT', () => {
     });
 
     existingBookReview = user.bookReviews[0];
-    uuid = user.uuid;
   });
 
   afterAll(async () => {
@@ -49,7 +49,7 @@ describe('/book-reviews/[bookReviewId] PUT', () => {
       body: JSON.stringify(updates),
       method: 'PUT',
     });
-    request.cookies.set(projectConfig.auth.cookieName, uuid);
+    establishAuth({ request, user });
 
     const response = await PUT(request, {
       params: { bookReviewId: existingBookReview.id.toString() },
@@ -83,7 +83,7 @@ describe('/book-reviews/[bookReviewId] PUT', () => {
       body: JSON.stringify({ rating: 'not number' }),
       method: 'PUT',
     });
-    request.cookies.set(projectConfig.auth.cookieName, uuid);
+    establishAuth({ request, user });
 
     const response = await PUT(request, {
       params: { bookReviewId: existingBookReview.id.toString() },
@@ -106,7 +106,7 @@ describe('/book-reviews/[bookReviewId] PUT', () => {
       body: JSON.stringify({ rating: 1 }),
       method: 'PUT',
     });
-    request.cookies.set(projectConfig.auth.cookieName, uuid);
+    establishAuth({ request, user });
 
     const response = await PUT(request, {
       params: { bookReviewId: otherUsersBookReview.id.toString() },


### PR DESCRIPTION
## Description

- some minor cleanup of the book-prompts POST route
- refactor out establishing auth in the test code to a single function to encapsulate the logic

## Tests

- existing tests cover refactor
