### PR TITLE
feat: protected layout auth check

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import useAppContext from '@/hooks/useAppContext';
+import useLoginError from '@/hooks/useLoginError';
+import LoginError from '@/types/LoginError';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function ProtectedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const {
+    auth: { isLoggedIn },
+  } = useAppContext();
+  const router = useRouter();
+  const { buildLoginErrorUrl } = useLoginError();
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      router.push(buildLoginErrorUrl(LoginError.UNAUTHORIZED));
+    }
+  }, [isLoggedIn, router, buildLoginErrorUrl]);
+
+  if (!isLoggedIn) {
+    return <></>;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Description

- To improve the UX, add a layout within the (protected) pages that checks to see if the user is logged in. If not, we redirect to the login page. Else we show the pages as normal.

## Tests

Manual verification demo:


https://github.com/user-attachments/assets/ae3c4b0d-8d24-428f-af86-cbd6c47bcca7

