### PR TITLE
test: simplify CI

### DIFF
--- a/.github/workflows/ci.js.yml
+++ b/.github/workflows/ci.js.yml
@@ -2,8 +2,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -36,13 +34,3 @@ jobs:
         run: npm run ci:db:reset
       - name: Run integration tests
         run: npm run ci:test
-  build:
-    name: Next.js Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Setup Environment
-        uses: ./.github/actions/setup-env
-      - name: Run build
-        run: NODE_ENV=test npm run build


### PR DESCRIPTION
## Description
- remove the next build from the CI, since it wasn't providing much, was taking a while, and we're going to be doing this as part of docker in the future.
- only run CI on pull requests, not on main
