### PR TITLE
chore: Next.js buildId is git sha

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,12 @@
+import { execSync } from 'child_process';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
     dirs: ['integration-tests', 'prisma', 'src', 'test-setup'],
+  },
+  generateBuildId: async () => {
+    return execSync('git rev-parse --short HEAD').toString().trim();
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Description
- To help in identifying what is running in production, set the Next.js buildId to the git sha. This can be any unique number, and by using the git sha, we can trace it back to the code.

## Tests
- Locally ran `npm run build` then `npm start` and viewed the page source to find:

![buildid](https://github.com/user-attachments/assets/b6e731d6-b148-4a17-9029-ab0d7e4edb6b)
