### PR TITLE
feat: simplify what Types omit

### DIFF
--- a/integration-tests/tests/book-prompts/get-book-prompt.test.ts
+++ b/integration-tests/tests/book-prompts/get-book-prompt.test.ts
@@ -31,15 +31,7 @@ describe('/api/protected/book-prompts/[bookPromptId] GET Integration Test', () =
                   },
                 },
               },
-              omit: {
-                bookId: true,
-                bookPromptId: true,
-              },
             },
-          },
-          omit: {
-            aiModel: true,
-            userId: true,
           },
         },
       },
@@ -95,15 +87,7 @@ describe('/api/protected/book-prompts/[bookPromptId] GET Integration Test', () =
                     },
                   },
                 },
-                omit: {
-                  bookId: true,
-                  bookPromptId: true,
-                },
               },
-            },
-            omit: {
-              aiModel: true,
-              userId: true,
             },
           },
         },

--- a/integration-tests/tests/book-reviews/get-book-reviews.test.ts
+++ b/integration-tests/tests/book-reviews/get-book-reviews.test.ts
@@ -15,11 +15,7 @@ describe('/book-reviews GET', () => {
   beforeAll(async () => {
     user = await prisma.user.findFirstOrThrow({
       include: {
-        bookReviews: {
-          omit: {
-            userId: true,
-          },
-        },
+        bookReviews: true,
       },
       where: { email: USER_WITH_REVIEWS_EMAIL },
     });

--- a/integration-tests/tests/book-reviews/put-book-review.test.ts
+++ b/integration-tests/tests/book-reviews/put-book-review.test.ts
@@ -22,11 +22,7 @@ describe('/book-reviews/[bookReviewId] PUT', () => {
   beforeAll(async () => {
     user = await prisma.user.findFirstOrThrow({
       include: {
-        bookReviews: {
-          omit: {
-            userId: true,
-          },
-        },
+        bookReviews: true,
       },
       where: { email: USER_WITH_REVIEWS_EMAIL },
     });

--- a/src/app/api/protected/book-prompts/[bookPromptId]/route.ts
+++ b/src/app/api/protected/book-prompts/[bookPromptId]/route.ts
@@ -28,16 +28,8 @@ export async function GET(
               },
             },
           },
-          omit: {
-            bookId: true,
-            bookPromptId: true,
-          },
           orderBy: { confidenceScore: 'desc' },
         },
-      },
-      omit: {
-        aiModel: true,
-        userId: true,
       },
       where: {
         id: bookPromptId,

--- a/src/app/api/protected/book-prompts/route.ts
+++ b/src/app/api/protected/book-prompts/route.ts
@@ -47,10 +47,6 @@ export async function GET(
           },
         },
       },
-      omit: {
-        aiModel: true,
-        userId: true,
-      },
       orderBy: { createdAt: 'desc' },
       where: { userId: session.user.id },
     });
@@ -186,16 +182,8 @@ export async function POST(
                 },
               },
             },
-            omit: {
-              bookId: true,
-              bookPromptId: true,
-            },
             orderBy: { confidenceScore: 'desc' },
           },
-        },
-        omit: {
-          aiModel: true,
-          userId: true,
         },
         where: { id: bookPromptId },
       });

--- a/src/app/api/protected/book-reviews/[bookReviewId]/route.ts
+++ b/src/app/api/protected/book-reviews/[bookReviewId]/route.ts
@@ -51,9 +51,6 @@ export async function PUT(
       data: {
         rating,
       },
-      omit: {
-        userId: true,
-      },
       where: { id: bookReviewId, userId: session.user.id },
     });
 

--- a/src/app/api/protected/book-reviews/route.ts
+++ b/src/app/api/protected/book-reviews/route.ts
@@ -31,9 +31,7 @@ export async function GET(
 
   try {
     const bookReviews = await prisma.bookReview.findMany({
-      omit: {
-        userId: true,
-      },
+      orderBy: { createdAt: 'desc' },
       where: { userId: session.user.id },
     });
 
@@ -90,9 +88,6 @@ export async function POST(
         user: {
           connect: { id: session.user.id },
         },
-      },
-      omit: {
-        userId: true,
       },
     });
 

--- a/src/lib/fakes/recommendation.fake.ts
+++ b/src/lib/fakes/recommendation.fake.ts
@@ -29,15 +29,8 @@ export function fakeBookRecommendation(): BookRecommendation {
 }
 
 export function fakeBookRecommendationHydrated(): BookRecommendationHydrated {
-  const { confidenceScore, createdAt, explanation, id, updatedAt } =
-    fakeBookRecommendation();
-
   return {
+    ...fakeBookRecommendation(),
     book: fakeBookHydrated(),
-    confidenceScore,
-    createdAt,
-    explanation,
-    id,
-    updatedAt,
   };
 }

--- a/src/lib/middleware.test.ts
+++ b/src/lib/middleware.test.ts
@@ -2,13 +2,16 @@ import projectConfig from '@/config/index';
 import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 import { fakeUser } from '@/lib/fakes/user.fake';
 import { authMiddleware } from '@/lib/middleware';
-import prisma from '@/lib/prisma';
+import prisma, { ExtendedPrismaClient } from '@/lib/prisma';
 import { NextRequest } from 'next/server';
 
 const url = 'http://localhost';
 const authCookieName = projectConfig.auth.cookieName;
 
-const mockFind = jest.spyOn(prisma.user, 'findFirst');
+const mockFind = jest.spyOn(
+  prisma.user as ExtendedPrismaClient['user'],
+  'findFirst',
+);
 
 describe('src/lib/middleware', () => {
   beforeEach(() => {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,14 +1,19 @@
 // https://www.prisma.io/docs/orm/more/help-and-troubleshooting/help-articles/nextjs-prisma-client-dev-practices
 
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
+
+const omitConfig = {
+  bookPrompt: {
+    aiModel: true,
+  },
+  user: {
+    password: true,
+  },
+} satisfies Prisma.GlobalOmitConfig;
 
 const prismaClientSingleton = () => {
   return new PrismaClient({
-    omit: {
-      user: {
-        password: true,
-      },
-    },
+    omit: omitConfig,
   });
 };
 

--- a/src/lib/prompts/RecommendBooksPrompt.ts
+++ b/src/lib/prompts/RecommendBooksPrompt.ts
@@ -45,9 +45,7 @@ titles, just to find that perfect book recommendation.
 
   async getUserPrompt(): Promise<string> {
     const books = await prisma.bookReview.findMany({
-      orderBy: {
-        rating: 'desc',
-      },
+      orderBy: { rating: 'desc' },
       select: {
         book: {
           select: {

--- a/src/types/BookPrompt.ts
+++ b/src/types/BookPrompt.ts
@@ -1,5 +1,5 @@
 import { BookPrompt as PrismaBookPrompt } from '@prisma/client';
 
-type BookPrompt = Omit<PrismaBookPrompt, 'userId' | 'aiModel'>;
+type BookPrompt = Omit<PrismaBookPrompt, 'aiModel'>;
 
 export default BookPrompt;

--- a/src/types/BookPromptTable.ts
+++ b/src/types/BookPromptTable.ts
@@ -1,10 +1,7 @@
 import BookPrompt from '@/types/BookPrompt';
 import { Genre } from '@/types/Genre';
 
-export type BookPromptTable = Omit<
-  BookPrompt,
-  'promptGenreId' | 'promptSubgenreId'
-> & {
+export type BookPromptTable = BookPrompt & {
   promptGenre: Genre | null;
   promptSubgenre: Genre | null;
 };

--- a/src/types/BookRecommendation.ts
+++ b/src/types/BookRecommendation.ts
@@ -1,8 +1,5 @@
 import { BookRecommendation as PrismaBookRecommendation } from '@prisma/client';
 
-type BookRecommendation = Omit<
-  PrismaBookRecommendation,
-  'bookPromptId' | 'bookId'
->;
+type BookRecommendation = PrismaBookRecommendation;
 
 export default BookRecommendation;

--- a/src/types/BookReview.ts
+++ b/src/types/BookReview.ts
@@ -1,5 +1,5 @@
 import { BookReview as PrismaBookReview } from '@prisma/client';
 
-type BookReview = Omit<PrismaBookReview, 'userId'>;
+type BookReview = PrismaBookReview;
 
 export default BookReview;


### PR DESCRIPTION
## Description
- We originally omitted many of the ids from types to avoid exposing those details to the client. But with the new cuid2 IDs, we can remove those omit clauses and simplify the types.
- Move omitting the aiModel from the bookPrompt to the global level. This required casting the omit config as shown in this discussion thread: https://github.com/prisma/prisma/discussions/23924#discussioncomment-10142568

## Tests
- existing tests cover refactor