### PR TITLE
feat: DataTable custom cell/header

### DIFF
--- a/src/components/book-prompt/BookPromptsTable.tsx
+++ b/src/components/book-prompt/BookPromptsTable.tsx
@@ -1,32 +1,93 @@
 import DataTable from '@/components/table/DataTable';
 import SortableHeader from '@/components/table/SortableHeader';
+import { TableCell, TableHead } from '@/components/ui/table';
 import { BookPromptTable } from '@/types/BookPromptTable';
 import { ColumnDef } from '@tanstack/react-table';
+import Link from 'next/link';
 
-const columns: ColumnDef<BookPromptTable>[] = [
+const getColumns = (linkPathname: string): ColumnDef<BookPromptTable>[] => [
   {
     accessorKey: 'promptText',
-    header: ({ column }) => (
-      <SortableHeader column={column} text="Prompt" className="justify-start" />
-    ),
+    meta: {
+      cell: (props) => (
+        <TableCell className="p-0 contents">
+          <Link
+            href={`${linkPathname}/${props.row.id}`}
+            className="table-cell align-middle p-2 w-[450px] max-w-[450px]"
+          >
+            <div className="overflow-hidden text-ellipsis whitespace-nowrap">
+              <>{props.getValue()}</>
+            </div>
+          </Link>
+        </TableCell>
+      ),
+      header: ({ column }) => (
+        <TableHead className="w-[450px] max-w-[450px]">
+          <SortableHeader
+            column={column}
+            text="Book Prompt"
+            className="justify-start"
+            showPlaceholderSortIconSpace={false}
+          />
+        </TableHead>
+      ),
+    },
   },
   {
     accessorFn: (bookPrompt) => bookPrompt.promptGenre?.displayName,
-    header: ({ column }) => (
-      <SortableHeader column={column} text="Genre" className="justify-start" />
-    ),
     id: 'genre',
+    meta: {
+      cell: (props) => (
+        <TableCell className="p-0 contents">
+          <Link
+            href={`${linkPathname}/${props.row.id}`}
+            className="table-cell align-middle p-2 w-[100px] max-w-[100px]"
+          >
+            <div className="overflow-hidden text-ellipsis whitespace-nowrap">
+              <>{props.getValue()}</>
+            </div>
+          </Link>
+        </TableCell>
+      ),
+      header: ({ column }) => (
+        <TableHead className="w-[100px] max-w-[100px]">
+          <SortableHeader
+            column={column}
+            text="Genre"
+            className="justify-start"
+            showPlaceholderSortIconSpace={false}
+          />
+        </TableHead>
+      ),
+    },
   },
   {
     accessorFn: (bookPrompt) => bookPrompt.promptSubgenre?.displayName,
-    header: ({ column }) => (
-      <SortableHeader
-        column={column}
-        text="Subgenre"
-        className="justify-start"
-      />
-    ),
     id: 'subgenre',
+    meta: {
+      cell: (props) => (
+        <TableCell className="p-0 contents">
+          <Link
+            href={`${linkPathname}/${props.row.id}`}
+            className="table-cell align-middle p-2 w-[100px] max-w-[100px]"
+          >
+            <div className="overflow-hidden text-ellipsis whitespace-nowrap">
+              <>{props.getValue()}</>
+            </div>
+          </Link>
+        </TableCell>
+      ),
+      header: ({ column }) => (
+        <TableHead className="w-[100px] max-w-[100px]">
+          <SortableHeader
+            column={column}
+            text="Subgenre"
+            className="justify-start"
+            showPlaceholderSortIconSpace={false}
+          />
+        </TableHead>
+      ),
+    },
   },
   {
     accessorFn: (bookPrompt) =>
@@ -52,7 +113,7 @@ export default function BookPromptsTable({
 }) {
   return (
     <DataTable
-      columns={columns}
+      columns={getColumns(linkPathname)}
       data={bookPrompts}
       isLoading={isLoading}
       linkPathname={linkPathname}

--- a/src/components/stories/book-prompt/BookPromptsTable.stories.tsx
+++ b/src/components/stories/book-prompt/BookPromptsTable.stories.tsx
@@ -12,10 +12,10 @@ type Story = StoryObj<typeof BookPromptsTable>;
 
 export const Default: Story = {
   render: () => {
-    const bookPrompts = _.times(20, () => fakeBookPromptTable());
+    const bookPrompts = _.times(100, () => fakeBookPromptTable());
 
     return (
-      <div>
+      <div className="max-w-[768px]">
         <BookPromptsTable bookPrompts={bookPrompts} linkPathname="#" />
       </div>
     );

--- a/src/components/stories/table/DataTable.stories.tsx
+++ b/src/components/stories/table/DataTable.stories.tsx
@@ -1,6 +1,6 @@
 import DataTable from '@/components/table/DataTable';
 import SortableHeader from '@/components/table/SortableHeader';
-import { TableCell, TableRow } from '@/components/ui/table';
+import { TableCell, TableHead, TableRow } from '@/components/ui/table';
 import { faker } from '@faker-js/faker';
 import { Meta, StoryObj } from '@storybook/react';
 import { ColumnDef } from '@tanstack/react-table';
@@ -172,6 +172,117 @@ export const AdditionalChildren: Story = {
           columns={columns}
           data={data}
           tableBodyAdditionalChildren={tableBodyAdditionalChildren}
+        />
+      </div>
+    );
+  },
+};
+
+export const FixedWithCustomCell: Story = {
+  render: () => {
+    const customColumns: ColumnDef<DataTableEntity>[] = [
+      {
+        accessorKey: 'name',
+        meta: {
+          cell: (props) => (
+            <TableCell className="w-[40%]">
+              <div className="overflow-hidden text-ellipsis whitespace-nowrap">
+                <>{props.getValue()}</>
+              </div>
+            </TableCell>
+          ),
+          header: ({ column }) => (
+            <TableHead className="w-[40%]">
+              <SortableHeader
+                column={column}
+                text="Name"
+                className="justify-start"
+                showPlaceholderSortIconSpace={false}
+              />
+            </TableHead>
+          ),
+        },
+      },
+      {
+        accessorKey: 'description',
+        meta: {
+          cell: (props) => (
+            <TableCell className="w-[30%]">
+              <div className="overflow-hidden text-ellipsis whitespace-nowrap">
+                <>{props.getValue()}</>
+              </div>
+            </TableCell>
+          ),
+          header: ({ column }) => (
+            <TableHead className="w-[30%]">
+              <SortableHeader
+                column={column}
+                text="Description"
+                className="justify-start"
+                showPlaceholderSortIconSpace={false}
+              />
+            </TableHead>
+          ),
+        },
+      },
+      {
+        accessorFn: (entity) => entity.date.toLocaleDateString(),
+        id: 'date',
+        meta: {
+          cell: (props) => (
+            <TableCell className="w-[10%]">
+              <div className="text-right">
+                <>{props.getValue()}</>
+              </div>
+            </TableCell>
+          ),
+          header: ({ column }) => (
+            <TableHead className="w-[10%]">
+              <SortableHeader
+                column={column}
+                text="Date"
+                className="text-right"
+                showPlaceholderSortIconSpace={false}
+              />
+            </TableHead>
+          ),
+        },
+      },
+      {
+        accessorKey: 'num',
+        cell: (props) => (
+          <div className="text-right w-[100px]">
+            <>{props.getValue()}</>
+          </div>
+        ),
+        header: ({ column }) => (
+          <SortableHeader
+            column={column}
+            text="Number"
+            className="w-[100px]"
+            showPlaceholderSortIconSpace={false}
+          />
+        ),
+      },
+      {
+        accessorKey: 'bool',
+        cell: (props) => {
+          const bool = props.getValue();
+          return (
+            <div className="flex justify-end">
+              {bool ? <CheckCircle color="green" /> : <XCircle color="red" />}
+            </div>
+          );
+        },
+        header: () => <div className="text-right">Boolean</div>,
+      },
+    ];
+
+    return (
+      <div>
+        <DataTable
+          columns={customColumns}
+          data={_.times(50, fakeDataTableEntity)}
         />
       </div>
     );

--- a/src/components/table/SortableHeader.tsx
+++ b/src/components/table/SortableHeader.tsx
@@ -6,10 +6,12 @@ import { ArrowDown, ArrowUp } from 'lucide-react';
 export default function SortableHeader<T>({
   className,
   column,
+  showPlaceholderSortIconSpace = true,
   text,
 }: {
   className?: string;
   column: Column<T>;
+  showPlaceholderSortIconSpace?: boolean;
   text: string;
 }) {
   const sorted = column.getIsSorted();
@@ -21,9 +23,11 @@ export default function SortableHeader<T>({
         <ArrowDown className="ml-1 h-4 w-4" />
       )}
     </>
-  ) : (
+  ) : showPlaceholderSortIconSpace ? (
     // this acts as a placeholder for the sort icon
     <div className="ml-1 h-4 w-4"></div>
+  ) : (
+    <></>
   );
 
   return (

--- a/src/lib/fakes/bookPrompt.fake.ts
+++ b/src/lib/fakes/bookPrompt.fake.ts
@@ -12,7 +12,10 @@ export function fakeBookPrompt(): BookPrompt {
     id: faker.string.nanoid(),
     promptGenreId: faker.string.nanoid(),
     promptSubgenreId: faker.string.nanoid(),
-    promptText: faker.lorem.sentence(),
+    promptText: faker.lorem.sentence({
+      max: 20,
+      min: 2,
+    }),
     updatedAt: faker.date.past(),
     userId: faker.string.nanoid(),
   };


### PR DESCRIPTION
## Description
- To allow for fixed width and any other cell overrides, enable custom table cells and headers in the DataTable.
- change the BookPromptsTable to set custom width for the prompt and genres.

## Tests
- add stories to demo

https://github.com/user-attachments/assets/2596ea3e-d598-4f6a-9b36-4c9add02561c

