### PR TITLE
feat: ReviewStar animation updates

### DIFF
--- a/src/components/ReviewStar.tsx
+++ b/src/components/ReviewStar.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/tailwind-utils';
+import { motion, useAnimate } from 'framer-motion';
 import { LucideProps, StarIcon } from 'lucide-react';
 
 type ReviewStarProps = Omit<LucideProps, 'ref'> & {
@@ -13,22 +14,38 @@ const ReviewStar = ({
   onClick,
   size,
   strokeWidth,
-}: ReviewStarProps) => (
-  <StarIcon
-    onClick={onClick}
-    size={size || 26}
-    strokeWidth={strokeWidth || 1}
-    className={cn(
-      'fill-slate-100',
-      filled
-        ? 'fill-yellow-300'
-        : 'hover:fill-yellow-300 transition-[fill] duration-200',
-      filledFaded && 'fill-yellow-100',
-      onClick && 'cursor-pointer',
-      className,
-    )}
-  />
-);
+}: ReviewStarProps) => {
+  const [scope, animate] = useAnimate();
+
+  return (
+    <motion.div
+      onTap={() => {
+        animate(scope.current, { scale: 0.4 });
+        setTimeout(() => {
+          animate(scope.current, { scale: 1 });
+        }, 100);
+      }}
+      whileHover={{ scale: 1.5 }}
+      whileTap={{ scale: 0.8 }}
+    >
+      <StarIcon
+        ref={scope}
+        onClick={onClick}
+        size={size || 18}
+        strokeWidth={strokeWidth || 1}
+        className={cn(
+          'fill-slate-100',
+          filled
+            ? 'fill-yellow-300'
+            : 'hover:fill-yellow-300 transition-[fill] duration-200',
+          filledFaded && 'fill-yellow-100',
+          onClick && 'cursor-pointer',
+          className,
+        )}
+      />
+    </motion.div>
+  );
+};
 ReviewStar.displayName = 'ReviewStar';
 
 export default ReviewStar;

--- a/src/components/ReviewStars.tsx
+++ b/src/components/ReviewStars.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import ReviewStar from '@/components/ReviewStar';
-import { motion } from 'framer-motion';
 import _ from 'lodash';
 import { useState } from 'react';
 
@@ -28,7 +27,7 @@ export default function ReviewStars({ score, onSetScore }: ReviewStarsProps) {
       isHovering && hoverStarNumber! < currentStarNum && shouldBeFilled;
 
     return (
-      <motion.div
+      <div
         key={currentStarNum}
         onMouseEnter={() => {
           setHoverStarNumber(currentStarNum);
@@ -36,8 +35,6 @@ export default function ReviewStars({ score, onSetScore }: ReviewStarsProps) {
         onMouseLeave={() => {
           setHoverStarNumber(undefined);
         }}
-        whileHover={{ scale: 1.2 }}
-        whileTap={{ scale: 0.8 }}
       >
         <ReviewStar
           filled={filled}
@@ -50,7 +47,7 @@ export default function ReviewStars({ score, onSetScore }: ReviewStarsProps) {
             }
           }}
         />
-      </motion.div>
+      </div>
     );
   });
 

--- a/src/components/stories/ReviewStar.stories.tsx
+++ b/src/components/stories/ReviewStar.stories.tsx
@@ -3,6 +3,11 @@ import { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof ReviewStar> = {
   component: ReviewStar,
+  render: (args) => (
+    <div className="w-[18px]">
+      <ReviewStar {...args} />
+    </div>
+  ),
 };
 
 export default meta;


### PR DESCRIPTION
## Description
- Noticed the ReviewStar wasn't animating when the user clicked rather than tap and hold. So added an additional animation to the `onTap` trigger so that all clicks will register the design.
- Moved the animation logic to ReviewStar to keep things simple

## Tests
- Update the ReviewStar story to bound the size of the component

storybook demo:

https://github.com/user-attachments/assets/5b96f9be-9a90-4196-84e4-f148f5163a6f

