### PR TITLE
feat: author/book reviews create/update changes

### DIFF
--- a/integration-tests/tests/author-reviews/put-author-review.test.ts
+++ b/integration-tests/tests/author-reviews/put-author-review.test.ts
@@ -79,6 +79,23 @@ describe('/author-reviews/[authorReviewId] PUT', () => {
     });
   });
 
+  it('should fail to update without required fields', async () => {
+    const request = new NextRequest(url, {
+      body: JSON.stringify({}),
+      method: 'PUT',
+    });
+    establishAuth({ request, user });
+
+    const response = await PUT(request, {
+      params: { authorReviewId: existingAuthorReview.id.toString() },
+    });
+
+    expect(response.status).toEqual(400);
+    expect(await response.json()).toEqual({
+      error: 'Validation error: Required at "rating"',
+    });
+  });
+
   it('should fail to update with bad data', async () => {
     const request = new NextRequest(url, {
       body: JSON.stringify({ rating: 'not number' }),

--- a/integration-tests/tests/book-reviews/put-book-review.test.ts
+++ b/integration-tests/tests/book-reviews/put-book-review.test.ts
@@ -79,6 +79,23 @@ describe('/book-reviews/[bookReviewId] PUT', () => {
     });
   });
 
+  it('should fail to update without required fields', async () => {
+    const request = new NextRequest(url, {
+      body: JSON.stringify({}),
+      method: 'PUT',
+    });
+    establishAuth({ request, user });
+
+    const response = await PUT(request, {
+      params: { bookReviewId: existingBookReview.id.toString() },
+    });
+
+    expect(response.status).toEqual(400);
+    expect(await response.json()).toEqual({
+      error: 'Validation error: Required at "rating"',
+    });
+  });
+
   it('should fail to update with bad data', async () => {
     const request = new NextRequest(url, {
       body: JSON.stringify({ rating: 'not number' }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@faker-js/faker": "9.0.1",
+        "@paralleldrive/cuid2": "2.2.2",
         "@prisma/client": "6.2.1",
         "@radix-ui/react-dialog": "1.1.4",
         "@radix-ui/react-icons": "1.3.0",
@@ -4006,6 +4007,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4057,6 +4070,15 @@
       "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "9.0.1",
+    "@paralleldrive/cuid2": "2.2.2",
     "@prisma/client": "6.2.1",
     "@radix-ui/react-dialog": "1.1.4",
     "@radix-ui/react-icons": "1.3.0",

--- a/src/app/api/protected/author-reviews/[authorReviewId]/route.ts
+++ b/src/app/api/protected/author-reviews/[authorReviewId]/route.ts
@@ -15,7 +15,7 @@ import { fromZodError } from 'zod-validation-error';
 export type PutRequestBody = AuthorReviewUpdateInput;
 
 const putSchema: toZod<PutRequestBody> = z.object({
-  rating: z.number().optional(),
+  rating: z.number(),
 });
 
 export type PutResponseBody = {

--- a/src/app/api/protected/author-reviews/route.ts
+++ b/src/app/api/protected/author-reviews/route.ts
@@ -48,6 +48,7 @@ export type PostRequestBody = AuthorReviewCreateInput;
 
 const postSchema: toZod<PostRequestBody> = z.object({
   authorId: z.string(),
+  id: z.string().optional(),
   rating: z.number(),
 });
 
@@ -77,13 +78,14 @@ export async function POST(
       throw new BadRequestError(message.toString());
     }
 
-    const { authorId, rating } = validatedBody.data;
+    const { authorId, id, rating } = validatedBody.data;
 
     const authorReview = await prisma.authorReview.create({
       data: {
         author: {
           connect: { id: authorId },
         },
+        id,
         rating,
         user: {
           connect: { id: session.user.id },

--- a/src/app/api/protected/book-reviews/[bookReviewId]/route.ts
+++ b/src/app/api/protected/book-reviews/[bookReviewId]/route.ts
@@ -15,7 +15,7 @@ import { fromZodError } from 'zod-validation-error';
 export type PutRequestBody = BookReviewUpdateInput;
 
 const putSchema: toZod<PutRequestBody> = z.object({
-  rating: z.number().optional(),
+  rating: z.number(),
 });
 
 export type PutResponseBody = {

--- a/src/app/api/protected/book-reviews/route.ts
+++ b/src/app/api/protected/book-reviews/route.ts
@@ -48,6 +48,7 @@ export type PostRequestBody = BookReviewCreateInput;
 
 const postSchema: toZod<PostRequestBody> = z.object({
   bookId: z.string(),
+  id: z.string().optional(),
   rating: z.number(),
 });
 
@@ -77,13 +78,14 @@ export async function POST(
       throw new BadRequestError(message.toString());
     }
 
-    const { bookId, rating } = validatedBody.data;
+    const { bookId, id, rating } = validatedBody.data;
 
     const bookReview = await prisma.bookReview.create({
       data: {
         book: {
           connect: { id: bookId },
         },
+        id,
         rating,
         user: {
           connect: { id: session.user.id },

--- a/src/types/AuthorReviewCreateInput.ts
+++ b/src/types/AuthorReviewCreateInput.ts
@@ -2,7 +2,7 @@ import { AuthorReview, Prisma } from '@prisma/client';
 
 type AuthorReviewCreateInput = Omit<
   Prisma.AuthorReviewCreateInput,
-  'id' | 'createdAt' | 'updatedAt' | 'user' | 'author'
+  'createdAt' | 'updatedAt' | 'user' | 'author'
 > & {
   authorId: AuthorReview['authorId'];
 };

--- a/src/types/AuthorReviewUpdateInput.ts
+++ b/src/types/AuthorReviewUpdateInput.ts
@@ -1,8 +1,5 @@
-import { Prisma } from '@prisma/client';
-
-type AuthorReviewUpdateInput = Omit<
-  Prisma.AuthorReviewUpdateInput,
-  'id' | 'createdAt' | 'updatedAt' | 'user' | 'author'
->;
+type AuthorReviewUpdateInput = {
+  rating: number;
+};
 
 export default AuthorReviewUpdateInput;

--- a/src/types/BookReviewCreateInput.ts
+++ b/src/types/BookReviewCreateInput.ts
@@ -2,7 +2,7 @@ import { BookReview, Prisma } from '@prisma/client';
 
 type BookReviewCreateInput = Omit<
   Prisma.BookReviewCreateInput,
-  'id' | 'createdAt' | 'updatedAt' | 'user' | 'book'
+  'createdAt' | 'updatedAt' | 'user' | 'book'
 > & {
   bookId: BookReview['bookId'];
 };

--- a/src/types/BookReviewUpdateInput.ts
+++ b/src/types/BookReviewUpdateInput.ts
@@ -1,8 +1,5 @@
-import { Prisma } from '@prisma/client';
-
-type BookReviewUpdateInput = Omit<
-  Prisma.BookReviewUpdateInput,
-  'id' | 'createdAt' | 'updatedAt' | 'user' | 'book'
->;
+type BookReviewUpdateInput = {
+  rating: number;
+};
 
 export default BookReviewUpdateInput;


### PR DESCRIPTION
## Description
- To allow the UI to specify the ID, update the author/book review create input to accept ID as optional input. In the POST methods, include it in the create calls. They should fail automatically if the ID already exists, b/c we have a unique primary key constraint for the column in the database.
- Simplify the update author/book review input to require rating in the input.

## Tests
- Add integration tests for POST, using cuid2 to generate the IDs
- Add integration tests for PUT, validating rating is required input