### PR TITLE
fix: useLoginError error url

### DIFF
--- a/src/hooks/useHandleError.test.ts
+++ b/src/hooks/useHandleError.test.ts
@@ -8,12 +8,20 @@ import { renderHook } from '@testing-library/react';
 
 const mockPush = jest.fn();
 jest.mock('next/navigation', () => ({
-  usePathname: () => '/path',
   useRouter: () => ({ push: mockPush }),
 }));
 
 describe('useHandleError', () => {
+  beforeEach(() => {
+    const originalLocation = window.location;
+    jest.spyOn(window, 'location', 'get').mockImplementation(() => ({
+      ...originalLocation,
+      pathname: '/path',
+    }));
+  });
+
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.resetAllMocks();
   });
 

--- a/src/hooks/useHandleError.test.ts
+++ b/src/hooks/useHandleError.test.ts
@@ -22,7 +22,6 @@ describe('useHandleError', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-    jest.resetAllMocks();
   });
 
   it('route to the login page on UnauthorizedError', () => {

--- a/src/hooks/useLoginError.test.ts
+++ b/src/hooks/useLoginError.test.ts
@@ -16,7 +16,12 @@ describe('useLoginError', () => {
     let buildLoginErrorUrl: UseLoginErrorResult['buildLoginErrorUrl'];
 
     beforeEach(() => {
-      mockUsePathname.mockReturnValue('/');
+      const originalLocation = window.location;
+      jest.spyOn(window, 'location', 'get').mockImplementation(() => ({
+        ...originalLocation,
+        pathname: '/foo',
+      }));
+
       ({
         result: {
           current: { buildLoginErrorUrl },
@@ -24,15 +29,19 @@ describe('useLoginError', () => {
       } = renderHook(() => useLoginError()));
     });
 
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it('should build the correct invalid login url', () => {
       expect(buildLoginErrorUrl(LoginError.INVALID_LOGIN)).toEqual(
-        '/login?login-error=invalid-login&return-url=/',
+        '/login?login-error=invalid-login&return-url=/foo',
       );
     });
 
     it('should build the correct unauthorized url', () => {
       expect(buildLoginErrorUrl(LoginError.UNAUTHORIZED)).toEqual(
-        '/login?login-error=unauthorized&return-url=/',
+        '/login?login-error=unauthorized&return-url=/foo',
       );
     });
   });

--- a/src/hooks/useLoginError.ts
+++ b/src/hooks/useLoginError.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import LoginError from '@/types/LoginError';
-import { usePathname } from 'next/navigation';
 import { useCallback } from 'react';
 
 export type UseLoginErrorResult = {
@@ -26,14 +25,9 @@ const LOGIN_ERROR_VALUES = {
 const RETURN_URL_KEY = 'return-url';
 
 export default function useLoginError(): UseLoginErrorResult {
-  const pathname = usePathname();
-
-  const buildLoginErrorUrl = useCallback(
-    (loginError: LoginError) => {
-      return `/login?${LOGIN_ERROR_KEY}=${LOGIN_ERROR_VALUES[loginError]}&${RETURN_URL_KEY}=${pathname}`;
-    },
-    [pathname],
-  );
+  const buildLoginErrorUrl = useCallback((loginError: LoginError) => {
+    return `/login?${LOGIN_ERROR_KEY}=${LOGIN_ERROR_VALUES[loginError]}&${RETURN_URL_KEY}=${window.location.pathname}`;
+  }, []);
 
   const parseLoginErrorUrl = useCallback((searchParams: URLSearchParams) => {
     const loginError = searchParams.get(LOGIN_ERROR_KEY);


### PR DESCRIPTION
## Description
This was a bit tricky to trace down, but noticed that when using the new protected context that the data was being reloaded on each page request. After a bit of digging, found out that the culprit was the fact that all the client API calls had an error catch to handle errors, and at it's core, `buildLoginErrorUrl` was being rebuilt each page request since `usePathname` was updating the path (this makes sense, you change a page and it requires a new path update). However, we shouldn't require all downstream uses to re-evaluate every page change, especially when we want to build state only once.

So, in place of that let's just use `window.location.pathname`, which is updated as the pages changes but doesn't require React to re-build the function.

## Tests
- updated unit test and included an actual path to verify
- manual verification of attempting to navigate to a page after login expires, and redirect navigates to the original requested page after successful login:

https://github.com/user-attachments/assets/c3b96fc6-b2e3-478e-a4fb-4dcbcb8ebc1e


