### PR TITLE
feat: ProtectedContext (book reviews)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,7 @@ export const config: Config = {
   setupFilesAfterEnv: [
     '<rootDir>/test-setup/fetch-polyfill.setup.ts',
     '<rootDir>/test-setup/openai-mock.setup.ts',
+    '<rootDir>/test-setup/text-encoding-polyfill.setup.ts',
   ],
   testPathIgnorePatterns: ['/node_modules/', '/integration-tests/'],
 };

--- a/src/app/(protected)/ProtectedContext.ts
+++ b/src/app/(protected)/ProtectedContext.ts
@@ -1,0 +1,37 @@
+import BookReview from '@/types/BookReview';
+import BookReviewCreateInput from '@/types/BookReviewCreateInput';
+import BookReviewUpdateInput from '@/types/BookReviewUpdateInput';
+import { createContext } from 'react';
+
+export type ProtectedContextType = {
+  // authorReviews: AuthorReview[];
+  bookReviews: BookReview[];
+  // createAuthorReview: ({
+  //   authorReview,
+  // }: {
+  //   authorReview: AuthorReviewCreateInput;
+  // }) => Promise<void>;
+  createBookReview: ({
+    bookReview,
+  }: {
+    bookReview: BookReviewCreateInput;
+  }) => Promise<void>;
+  // updateAuthorReview: ({
+  //   id,
+  //   updates,
+  // }: {
+  //   id: AuthorReview['id'];
+  //   updates: AuthorReviewUpdateInput;
+  // }) => Promise<void>;
+  updateBookReview: ({
+    id,
+    updates,
+  }: {
+    id: BookReview['id'];
+    updates: BookReviewUpdateInput;
+  }) => Promise<void>;
+};
+
+const ProtectedContext = createContext<ProtectedContextType | null>(null);
+
+export default ProtectedContext;

--- a/src/app/(protected)/ProtectedContextProvider.tsx
+++ b/src/app/(protected)/ProtectedContextProvider.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import ProtectedContext, {
+  ProtectedContextType,
+} from '@/app/(protected)/ProtectedContext';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import useBookReviews from '@/hooks/useBookReviews';
+import { useEffect } from 'react';
+
+export default function ProtectedContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { bookReviews, createBookReview, loadBookReviews, updateBookReview } =
+    useBookReviews();
+
+  useEffect(() => {
+    loadBookReviews();
+  }, [loadBookReviews]);
+
+  if (!bookReviews) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  const protectedContext: ProtectedContextType = {
+    bookReviews,
+    createBookReview,
+    updateBookReview,
+  };
+
+  return (
+    <ProtectedContext.Provider value={protectedContext}>
+      {children}
+    </ProtectedContext.Provider>
+  );
+}

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ProtectedContextProvider from '@/app/(protected)/ProtectedContextProvider';
 import useAppContext from '@/hooks/useAppContext';
 import useLoginError from '@/hooks/useLoginError';
 import LoginError from '@/types/LoginError';
@@ -27,5 +28,5 @@ export default function ProtectedLayout({
     return <></>;
   }
 
-  return <>{children}</>;
+  return <ProtectedContextProvider>{children}</ProtectedContextProvider>;
 }

--- a/src/app/(protected)/prompts/[bookPromptId]/page.tsx
+++ b/src/app/(protected)/prompts/[bookPromptId]/page.tsx
@@ -7,8 +7,8 @@ import BookRecommendationComponent from '@/components/recommendations/BookRecomm
 import { LoadingCircleOverlay } from '@/components/ui/loading-circle';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { Separator } from '@/components/ui/separator';
-import useBookReviews from '@/hooks/useBookReviews';
 import useHandleError from '@/hooks/useHandleError';
+import useProtectedContext from '@/hooks/useProtectedContext';
 import { getBookPrompt, postBookPrompt } from '@/lib/api';
 import BookPromptHydrated from '@/types/BookPromptHydrated';
 import { useRouter } from 'next/navigation';
@@ -24,7 +24,8 @@ export default function PromptPage({
   const [bookPrompt, setBookPrompt] = useState<BookPromptHydrated | null>(null);
   const { handleError } = useHandleError();
   const router = useRouter();
-  const { bookReviews, createBookReview, updateBookReview } = useBookReviews();
+  const { bookReviews, createBookReview, updateBookReview } =
+    useProtectedContext();
   const [isGeneratingBookPrompt, setIsGeneratingBookPrompt] = useState(false);
 
   const loadBookPrompt = useCallback(

--- a/src/hooks/useBookReviews.test.ts
+++ b/src/hooks/useBookReviews.test.ts
@@ -10,7 +10,6 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 
 jest.mock('next/navigation', () => ({
-  usePathname: () => '/path',
   useRouter: () => {},
 }));
 
@@ -54,8 +53,9 @@ describe('useBookReviews', () => {
   it('should load the book reviews', async () => {
     const { result } = renderHook(() => useBookReviews());
 
+    result.current.loadBookReviews();
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+      expect(result.current.bookReviews).toBeDefined();
     });
 
     expect(result.current.bookReviews).toEqual(
@@ -66,11 +66,12 @@ describe('useBookReviews', () => {
   it('should create a book review', async () => {
     const { result } = renderHook(() => useBookReviews());
 
+    result.current.loadBookReviews();
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+      expect(result.current.bookReviews).toBeDefined();
     });
 
-    expect(result.current.bookReviews.length).toEqual(3);
+    expect(result.current.bookReviews?.length).toEqual(3);
 
     const { createBookReview } = result.current;
     await act(async () => {
@@ -79,7 +80,7 @@ describe('useBookReviews', () => {
       });
     });
 
-    expect(result.current.bookReviews.length).toEqual(4);
+    expect(result.current.bookReviews?.length).toEqual(4);
     expect(result.current.bookReviews).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -93,8 +94,9 @@ describe('useBookReviews', () => {
   it('should update a book review', async () => {
     const { result } = renderHook(() => useBookReviews());
 
+    result.current.loadBookReviews();
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+      expect(result.current.bookReviews).toBeDefined();
     });
 
     expect(result.current.bookReviews).toEqual(

--- a/src/hooks/useBookReviews.ts
+++ b/src/hooks/useBookReviews.ts
@@ -1,9 +1,12 @@
+'use client';
+
 import useHandleError from '@/hooks/useHandleError';
 import { getBookReviews, postBookReviews, putBookReview } from '@/lib/api';
 import BookReview from '@/types/BookReview';
 import BookReviewCreateInput from '@/types/BookReviewCreateInput';
 import BookReviewUpdateInput from '@/types/BookReviewUpdateInput';
-import { useCallback, useEffect, useState } from 'react';
+import { createId } from '@paralleldrive/cuid2';
+import { useCallback, useState } from 'react';
 
 export type UseBookReviewsResult = {
   bookReviews: BookReview[];
@@ -12,7 +15,7 @@ export type UseBookReviewsResult = {
   }: {
     bookReview: BookReviewCreateInput;
   }) => Promise<void>;
-  isLoading: boolean;
+  loadBookReviews: () => Promise<void>;
   updateBookReview: ({
     id,
     updates,
@@ -22,51 +25,91 @@ export type UseBookReviewsResult = {
   }) => Promise<void>;
 };
 
+type OptimisticBookReview = Pick<BookReview, 'rating'> & {
+  id: string;
+  bookId?: string;
+};
+
 export default function useBookReviews() {
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [bookReviews, setBookReviews] = useState<BookReview[]>([]);
+  const [bookReviews, setBookReviews] = useState<BookReview[]>();
   const { handleError } = useHandleError();
 
   const loadBookReviews = useCallback(async () => {
     try {
-      setIsLoading(true);
       const reviews = await getBookReviews();
       setBookReviews(reviews);
     } catch (error) {
       /* istanbul ignore next */
       return handleError(error);
-    } finally {
-      setIsLoading(false);
     }
   }, [handleError]);
 
-  useEffect(() => {
-    loadBookReviews();
-  }, [loadBookReviews]);
+  const updateBookReviews = useCallback(
+    (optimisticBookReview: OptimisticBookReview) => {
+      setBookReviews((existingReviews) => {
+        /* istanbul ignore next */
+        if (!existingReviews) {
+          return undefined;
+        }
 
-  const replaceBookReview = useCallback(
-    (bookReview: BookReview) => {
-      setBookReviews([
-        ...bookReviews.filter((review) => review.id !== bookReview.id),
-        bookReview,
-      ]);
+        const existingBookReview = existingReviews.find(
+          (review) => review.id === optimisticBookReview.id,
+        );
+        if (existingBookReview) {
+          return [
+            ...existingReviews.filter(
+              (review) => review.id !== optimisticBookReview.id,
+            ),
+            {
+              ...existingBookReview,
+              ...optimisticBookReview,
+            },
+          ];
+        } else if (optimisticBookReview.bookId) {
+          const newBookReview: BookReview = {
+            ...optimisticBookReview,
+            bookId: optimisticBookReview.bookId,
+            createdAt: new Date(), // replaced by the server code
+            updatedAt: new Date(), // replaced by the server code
+            userId: '', // replaced by the server code
+          };
+          return existingReviews.concat(newBookReview);
+        }
+
+        /* istanbul ignore next */
+        return existingReviews;
+      });
     },
-    [bookReviews],
+    [],
   );
 
   const createBookReview = useCallback(
     async ({
       bookReview,
     }: Parameters<UseBookReviewsResult['createBookReview']>[0]) => {
+      /* istanbul ignore next */
+      if (!bookReviews) {
+        return;
+      }
+
       try {
-        const createdBookReview = await postBookReviews({ bookReview });
-        setBookReviews(bookReviews.concat(createdBookReview));
+        // optimistic update while we wait for the API
+        const optimisticBookReview = {
+          ...bookReview,
+          id: createId(),
+        };
+        updateBookReviews(optimisticBookReview);
+
+        const createdBookReview = await postBookReviews({
+          bookReview: optimisticBookReview,
+        });
+        updateBookReviews(createdBookReview);
       } catch (error) {
         /* istanbul ignore next */
         return handleError(error);
       }
     },
-    [bookReviews, handleError],
+    [bookReviews, handleError, updateBookReviews],
   );
 
   const updateBookReview = useCallback(
@@ -75,20 +118,26 @@ export default function useBookReviews() {
       updates,
     }: Parameters<UseBookReviewsResult['updateBookReview']>[0]) => {
       try {
+        // optimistic update while we wait for the API
+        updateBookReviews({
+          id,
+          rating: updates.rating,
+        });
+
         const updatedBookReview = await putBookReview({ id, updates });
-        replaceBookReview(updatedBookReview);
+        updateBookReviews(updatedBookReview);
       } catch (error) {
         /* istanbul ignore next */
         return handleError(error);
       }
     },
-    [handleError, replaceBookReview],
+    [handleError, updateBookReviews],
   );
 
   return {
     bookReviews,
     createBookReview,
-    isLoading,
+    loadBookReviews,
     updateBookReview,
   };
 }

--- a/src/hooks/useProtectedContext.test.tsx
+++ b/src/hooks/useProtectedContext.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import ProtectedContext, {
+  ProtectedContextType,
+} from '@/app/(protected)/ProtectedContext';
+import ProtectedContextProvider from '@/app/(protected)/ProtectedContextProvider';
+import useProtectedContext from '@/hooks/useProtectedContext';
+import { fakeBookReview } from '@/lib/fakes/bookReview.fake';
+import { BookReview } from '@prisma/client';
+import { renderHook, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { ReactNode } from 'react';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => {},
+}));
+
+describe('useProtectedContext', () => {
+  it('should return context when it exists', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ProtectedContext.Provider
+        value={{ foo: 'bar' } as unknown as ProtectedContextType}
+      >
+        {children}
+      </ProtectedContext.Provider>
+    );
+    const { result } = renderHook(() => useProtectedContext(), { wrapper });
+
+    expect(result.current).toEqual({ foo: 'bar' });
+  });
+
+  it('should throw error when no context exists', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() =>
+      renderHook(() => useProtectedContext()),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"useProtectedContext used outside of provider"`,
+    );
+  });
+
+  describe('with mock data', () => {
+    const BOOK_REVIEWS: BookReview[] = [fakeBookReview(), fakeBookReview()];
+    const server = setupServer(
+      rest.get('/api/protected/book-reviews', (_, res, ctx) => {
+        return res(ctx.json({ data: BOOK_REVIEWS }));
+      }),
+    );
+
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    let wrapper: ({ children }: { children: ReactNode }) => JSX.Element;
+    beforeEach(() => {
+      wrapper = ({ children }: { children: ReactNode }) => (
+        <ProtectedContextProvider>{children}</ProtectedContextProvider>
+      );
+    });
+
+    it('should load reviews on mount', async () => {
+      const { result } = renderHook(() => useProtectedContext(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.bookReviews).toEqual(
+          JSON.parse(JSON.stringify(BOOK_REVIEWS)),
+        );
+      });
+    });
+  });
+});

--- a/src/hooks/useProtectedContext.ts
+++ b/src/hooks/useProtectedContext.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import ProtectedContext, {
+  ProtectedContextType,
+} from '@/app/(protected)/ProtectedContext';
+import { useContext } from 'react';
+
+export default function useProtectedContext(): ProtectedContextType {
+  const context = useContext(ProtectedContext);
+
+  if (!context) {
+    throw new Error('useProtectedContext used outside of provider');
+  }
+
+  return context;
+}

--- a/test-setup/text-encoding-polyfill.setup.ts
+++ b/test-setup/text-encoding-polyfill.setup.ts
@@ -1,0 +1,3 @@
+import { TextDecoder, TextEncoder } from 'util';
+
+Object.assign(global, { TextDecoder, TextEncoder });


### PR DESCRIPTION
## Description
- add a ProtectedContext which stores the book reviews in state within the `(protected)` pages. This will load the book reviews only once, and still provide the create/update actions we had previously.
- enhance the create/update actions to be optimistic in nature -- they update the local data immediately, then make the API call, then update again with the returned data.
- the plan is to add author reviews next, so some placeholders still remain

## Tests
- add a polyfill to our test environment for TextEncoder, since we're using cuid2 in the book reviews to generate the ID.
- update and add tests for the hooks

manual demo of the book review state:

https://github.com/user-attachments/assets/913e7bc8-28ab-4345-beeb-a78b440e3e9a


