### PR TITLE
feat: DataTable default sort

### DIFF
--- a/src/components/book-reviews/BookReviewsTable.tsx
+++ b/src/components/book-reviews/BookReviewsTable.tsx
@@ -23,13 +23,15 @@ const getColumns = (
 
       return (
         <div className="flex items-center">
-          {book.imageUrl && (
+          {book.imageUrl ? (
             <Image
               alt={book.title}
               src={book.imageUrl}
               width={16}
               height={24}
             />
+          ) : (
+            <div className="border rounded-sm border-customPalette-300 w-[16px] h-[24px] flex justify-center items-center" />
           )}
         </div>
       );
@@ -124,6 +126,7 @@ export default function BookReviewsTable({
     <DataTable
       columns={getColumns(onSetBookReviewRating)}
       data={bookReviews}
+      defaultSortState={[{ desc: false, id: 'title' }]}
       isLoading={isLoading}
       noDataText="No reviews found"
     />

--- a/src/components/stories/table/DataTable.stories.tsx
+++ b/src/components/stories/table/DataTable.stories.tsx
@@ -35,7 +35,7 @@ const columns: ColumnDef<DataTableEntity>[] = [
     accessorFn: (entity) => entity.date.toLocaleDateString(),
     cell: (props) => (
       <div className="text-right">
-        <>{props.getValue()}</>
+        <>{props.getValue() as string}</>
       </div>
     ),
     header: () => <div className="text-right">Date</div>,
@@ -45,7 +45,7 @@ const columns: ColumnDef<DataTableEntity>[] = [
     accessorKey: 'num',
     cell: (props) => (
       <div className="text-right">
-        <>{props.getValue()}</>
+        <>{props.getValue() as string}</>
       </div>
     ),
     header: ({ column }) => <SortableHeader column={column} text="Number" />,
@@ -187,7 +187,7 @@ export const FixedWithCustomCell: Story = {
           cell: (props) => (
             <TableCell className="w-[40%]">
               <div className="overflow-hidden text-ellipsis whitespace-nowrap">
-                <>{props.getValue()}</>
+                <>{props.getValue() as string}</>
               </div>
             </TableCell>
           ),
@@ -209,7 +209,7 @@ export const FixedWithCustomCell: Story = {
           cell: (props) => (
             <TableCell className="w-[30%]">
               <div className="overflow-hidden text-ellipsis whitespace-nowrap">
-                <>{props.getValue()}</>
+                <>{props.getValue() as string}</>
               </div>
             </TableCell>
           ),
@@ -232,7 +232,7 @@ export const FixedWithCustomCell: Story = {
           cell: (props) => (
             <TableCell className="w-[10%]">
               <div className="text-right">
-                <>{props.getValue()}</>
+                <>{props.getValue() as string}</>
               </div>
             </TableCell>
           ),
@@ -252,7 +252,7 @@ export const FixedWithCustomCell: Story = {
         accessorKey: 'num',
         cell: (props) => (
           <div className="text-right w-[100px]">
-            <>{props.getValue()}</>
+            <>{props.getValue() as string}</>
           </div>
         ),
         header: ({ column }) => (
@@ -283,6 +283,20 @@ export const FixedWithCustomCell: Story = {
         <DataTable
           columns={customColumns}
           data={_.times(50, fakeDataTableEntity)}
+        />
+      </div>
+    );
+  },
+};
+
+export const DefaultSortState: Story = {
+  render: () => {
+    return (
+      <div>
+        <DataTable
+          columns={columns}
+          data={data}
+          defaultSortState={[{ desc: false, id: 'num' }]}
         />
       </div>
     );

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -41,6 +41,7 @@ declare module '@tanstack/react-table' {
 export type DataTableProps<TData, TValue> = {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  defaultSortState?: SortingState;
   idFieldName?: string;
   isFixedTable?: boolean;
   isLoading?: boolean;
@@ -52,6 +53,7 @@ export type DataTableProps<TData, TValue> = {
 export default function DataTable<TData, TValue>({
   columns,
   data,
+  defaultSortState = [],
   idFieldName = 'id',
   isFixedTable = false,
   isLoading = false,
@@ -63,7 +65,7 @@ export default function DataTable<TData, TValue>({
     pageIndex: 0, //initial page index
     pageSize: 10, //default page size
   });
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>(defaultSortState);
   const table = useReactTable({
     columns,
     data,


### PR DESCRIPTION
## Description
- The DataTable now allows for a default sort state
- Use this in the BookReviewsTable to set the default sort state to be the book title. This was done because during updates, we sometimes get a different order to the book reviews, which causes a re-ordering of the table. This can be confusing to the user, so set the sort state to Title initially, so at least on review update it won't change (though they can sort by rating if they want).
- while I'm here: provide an empty image box in the table when the book has no image

## Tests
storybook stories to demo the default sort state:

https://github.com/user-attachments/assets/a20bfe94-83d0-4cb5-8088-7ebc3d8fc765

screenshot of the empty image:
![empty](https://github.com/user-attachments/assets/2fa07e11-0b88-41a8-9160-b0a8c09f6b71)
